### PR TITLE
fix: change servlet headers type to string

### DIFF
--- a/arex-cli-parent/arex-server-extension/src/main/java/io/arex/cli/server/handler/ApiHandler.java
+++ b/arex-cli-parent/arex-server-extension/src/main/java/io/arex/cli/server/handler/ApiHandler.java
@@ -1,6 +1,7 @@
 package io.arex.cli.server.handler;
 
 import io.arex.foundation.model.ServiceEntranceMocker;
+import io.arex.foundation.serializer.SerializeUtils;
 import io.arex.foundation.util.AsyncHttpClientUtil;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpEntity;
@@ -13,7 +14,7 @@ import java.util.*;
 public abstract class ApiHandler {
 
     public Map<String, String> request(ServiceEntranceMocker servletMocker) {
-        Map<String, String> mockerHeader = servletMocker.getRequestHeaders();
+        Map<String, String> mockerHeader = SerializeUtils.deserialize(servletMocker.getRequestHeaders(), Map.class);
 
         Map<String, String> requestHeaders = new HashMap<>();
         requestHeaders.put(HttpHeaders.CONTENT_TYPE, "application/json;charset=UTF-8");

--- a/arex-cli-parent/arex-server-extension/src/test/java/io/arex/cli/server/handler/DebugHandlerTest.java
+++ b/arex-cli-parent/arex-server-extension/src/test/java/io/arex/cli/server/handler/DebugHandlerTest.java
@@ -54,7 +54,7 @@ class DebugHandlerTest {
     static Stream<Arguments> processCase() {
         Runnable mocker1 = () -> {};
         ServiceEntranceMocker servletMocker = new ServiceEntranceMocker();
-        servletMocker.setRequestHeaders(new HashMap<>());
+        servletMocker.setRequestHeaders("{}");
         Runnable mockerQuery = () -> Mockito.when(storageService.query(any(AbstractMocker.class))).thenReturn(servletMocker);
         Runnable mocker2 = () -> {
             mockerQuery.run();

--- a/arex-cli-parent/arex-server-extension/src/test/java/io/arex/cli/server/handler/ReplayHandlerTest.java
+++ b/arex-cli-parent/arex-server-extension/src/test/java/io/arex/cli/server/handler/ReplayHandlerTest.java
@@ -57,7 +57,7 @@ class ReplayHandlerTest {
         Runnable mocker1 = () -> {};
         Runnable mocker2 = () -> StorageService.INSTANCE = storageService;
         ServiceEntranceMocker servletMocker = new ServiceEntranceMocker();
-        servletMocker.setRequestHeaders(new HashMap<>());
+        servletMocker.setRequestHeaders("{}");
         Function<Class<? extends AbstractMocker>, OngoingStubbing<List<AbstractMocker>>> stub = clazz ->
                 Mockito.when(storageService.queryList(any(clazz), anyInt()));
         Runnable mocker3 = () -> stub.apply(ServiceEntranceMocker.class).thenReturn(Collections.singletonList(servletMocker));

--- a/arex-instrumentation-foundation/src/main/java/io/arex/foundation/model/MockerCategory.java
+++ b/arex-instrumentation-foundation/src/main/java/io/arex/foundation/model/MockerCategory.java
@@ -10,7 +10,7 @@ public enum MockerCategory {
     SERVICE_CALL(2, "ServiceCall"),
     DATABASE(3, "Database"),
     REDIS(4, "redis"),
-    DYNAMIC_CLASS(5, "dynamicClass");
+    DYNAMIC_CLASS(5, "dynamic");
     private final static Map<Integer, MockerCategory> CODE_VALUE_MAP = asMap(MockerCategory::getType);
 
     private final int type;

--- a/arex-instrumentation-foundation/src/main/java/io/arex/foundation/model/ServiceEntranceMocker.java
+++ b/arex-instrumentation-foundation/src/main/java/io/arex/foundation/model/ServiceEntranceMocker.java
@@ -19,9 +19,9 @@ public class ServiceEntranceMocker extends AbstractMocker {
     @JsonProperty("pattern")
     private String pattern;
     @JsonProperty("requestHeaders")
-    private Map<String, String> requestHeaders;
+    private String requestHeaders;
     @JsonProperty("responseHeaders")
-    private Map<String, String> responseHeaders;
+    private String responseHeaders;
     @JsonProperty("request")
     private String request;
 
@@ -55,19 +55,19 @@ public class ServiceEntranceMocker extends AbstractMocker {
         this.path = path;
     }
 
-    public Map<String, String> getRequestHeaders() {
+    public String getRequestHeaders() {
         return requestHeaders;
     }
 
-    public void setRequestHeaders(Map<String, String> requestHeaders) {
+    public void setRequestHeaders(String requestHeaders) {
         this.requestHeaders = requestHeaders;
     }
 
-    public Map<String, String> getResponseHeaders() {
+    public String getResponseHeaders() {
         return responseHeaders;
     }
 
-    public void setResponseHeaders(Map<String, String> responseHeaders) {
+    public void setResponseHeaders(String responseHeaders) {
         this.responseHeaders = responseHeaders;
     }
 

--- a/arex-instrumentation/netty/arex-netty-v4/src/main/java/io/arex/inst/netty/v4/server/RequestTracingHandler.java
+++ b/arex-instrumentation/netty/arex-netty-v4/src/main/java/io/arex/inst/netty/v4/server/RequestTracingHandler.java
@@ -8,6 +8,7 @@ import io.arex.foundation.listener.CaseListenerImpl;
 import io.arex.foundation.model.AbstractMocker;
 import io.arex.foundation.model.Constants;
 import io.arex.foundation.model.ServiceEntranceMocker;
+import io.arex.foundation.serializer.SerializeUtils;
 import io.arex.foundation.services.IgnoreService;
 import io.arex.foundation.util.StringUtil;
 import io.arex.inst.netty.v4.common.AttributeKey;
@@ -36,7 +37,7 @@ public class RequestTracingHandler extends ChannelInboundHandlerAdapter {
                 ServiceEntranceMocker mocker = new ServiceEntranceMocker();
                 mocker.setMethod(request.method().name());
                 mocker.setPath(request.uri());
-                mocker.setRequestHeaders(NettyHelper.parseHeaders(request.headers()));
+                mocker.setRequestHeaders(SerializeUtils.serialize(NettyHelper.parseHeaders(request.headers())));
 
                 ctx.channel().attr(AttributeKey.TRACING_MOCKER).set(mocker);
             }

--- a/arex-instrumentation/netty/arex-netty-v4/src/main/java/io/arex/inst/netty/v4/server/ResponseTracingHandler.java
+++ b/arex-instrumentation/netty/arex-netty-v4/src/main/java/io/arex/inst/netty/v4/server/ResponseTracingHandler.java
@@ -6,6 +6,7 @@ import io.arex.foundation.listener.CaseListenerImpl;
 import io.arex.foundation.model.AbstractMocker;
 import io.arex.foundation.model.Constants;
 import io.arex.foundation.model.ServiceEntranceMocker;
+import io.arex.foundation.serializer.SerializeUtils;
 import io.arex.foundation.util.StringUtil;
 import io.arex.inst.netty.v4.common.AttributeKey;
 import io.arex.inst.netty.v4.common.NettyHelper;
@@ -52,7 +53,8 @@ public class ResponseTracingHandler extends ChannelOutboundHandlerAdapter {
             return;
         }
 
-        ((ServiceEntranceMocker)mocker).setResponseHeaders(NettyHelper.parseHeaders(response.headers()));
+        ((ServiceEntranceMocker) mocker).setResponseHeaders(
+            SerializeUtils.serialize(NettyHelper.parseHeaders(response.headers())));
         channel.attr(AttributeKey.TRACING_MOCKER).set(mocker);
         appendHeader(response);
     }

--- a/arex-instrumentation/servlet/arex-httpservlet/src/main/java/io/arex/inst/httpservlet/ServletAdviceHelper.java
+++ b/arex-instrumentation/servlet/arex-httpservlet/src/main/java/io/arex/inst/httpservlet/ServletAdviceHelper.java
@@ -26,13 +26,22 @@ import java.util.concurrent.CompletableFuture;
  */
 public class ServletAdviceHelper {
     private static final Set<String> FILTERED_CONTENT_TYPE = new HashSet<>();
+    private static final Set<String> FILTERED_GET_URL_SUFFIX = new HashSet<>();
 
     static {
         FILTERED_CONTENT_TYPE.add("/javascript");
         FILTERED_CONTENT_TYPE.add("image/");
         FILTERED_CONTENT_TYPE.add("/font");
         FILTERED_CONTENT_TYPE.add("/pdf");
-        FILTERED_CONTENT_TYPE.add(".css");
+        FILTERED_CONTENT_TYPE.add("/css");
+
+        FILTERED_GET_URL_SUFFIX.add(".js");
+        FILTERED_GET_URL_SUFFIX.add(".css");
+        FILTERED_GET_URL_SUFFIX.add(".png");
+        FILTERED_GET_URL_SUFFIX.add(".woff");
+        FILTERED_GET_URL_SUFFIX.add(".pdf");
+        FILTERED_GET_URL_SUFFIX.add(".map");
+        FILTERED_GET_URL_SUFFIX.add(".ico");
     }
 
     public static <TRequest, TResponse> Pair<TRequest, TResponse> onServiceEnter(
@@ -150,16 +159,15 @@ public class ServletAdviceHelper {
         if (Boolean.parseBoolean(adapter.getRequestHeader(httpServletRequest, Constants.REPLAY_WARM_UP))) {
             return true;
         }
+
+        // Filter invalid servlet path suffix
+        if ("GET".equals(adapter.getMethod(httpServletRequest))) {
+            String servletPath = adapter.getServletPath(httpServletRequest);
+            return StringUtil.isEmpty(servletPath) || FILTERED_GET_URL_SUFFIX.stream().anyMatch(servletPath::contains);
+        }
+
+        // Filter invalid content-type
         String contentType = adapter.getContentType(httpServletRequest);
-        return isFilteredContentType(contentType) ||
-                isCssPath(adapter.getServletPath(httpServletRequest));
-    }
-
-    private static boolean isFilteredContentType(String contentType) {
-        return StringUtil.isEmpty(contentType) && FILTERED_CONTENT_TYPE.contains(contentType);
-    }
-
-    private static boolean isCssPath(String path) {
-        return StringUtil.isEmpty(path) || path.endsWith(".css");
+        return StringUtil.isEmpty(contentType) || FILTERED_CONTENT_TYPE.stream().anyMatch(contentType::contains);
     }
 }

--- a/arex-instrumentation/servlet/arex-httpservlet/src/main/java/io/arex/inst/httpservlet/ServletExtractor.java
+++ b/arex-instrumentation/servlet/arex-httpservlet/src/main/java/io/arex/inst/httpservlet/ServletExtractor.java
@@ -62,8 +62,8 @@ public class ServletExtractor<HttpServletRequest, HttpServletResponse> {
         mocker.setMethod(adapter.getMethod(httpServletRequest));
         mocker.setPath(adapter.getServletPath(httpServletRequest));
         mocker.setPattern(getPattern());
-        mocker.setRequestHeaders(getRequestHeaders());
-        mocker.setResponseHeaders(getResponseHeaders());
+        mocker.setRequestHeaders(SerializeUtils.serialize(getRequestHeaders()));
+        mocker.setResponseHeaders(SerializeUtils.serialize(getResponseHeaders()));
         mocker.setRequest(getRequest());
         mocker.setResponse(getResponse());
 


### PR DESCRIPTION
MongoDB uses the dot notation to access the elements of an array and to access the fields of an embedded document.

https://www.mongodb.com/docs/manual/core/document/#dot-notation