### PR TITLE
fix: httpclient header serialization

### DIFF
--- a/arex-instrumentation/httpclient/arex-httpclient-common/src/main/java/io/arex/inst/httpclient/common/HttpResponseWrapper.java
+++ b/arex-instrumentation/httpclient/arex-httpclient-common/src/main/java/io/arex/inst/httpclient/common/HttpResponseWrapper.java
@@ -93,6 +93,20 @@ public class HttpResponseWrapper {
         public String value() {
             return s;
         }
+
+        /**
+         * Just for serialization
+         */
+        public String getF() {
+            return f;
+        }
+
+        /**
+         * Just for serialization
+         */
+        public String getS() {
+            return s;
+        }
     }
 
     public static HttpResponseWrapper of(ExceptionWrapper exception) {


### PR DESCRIPTION
When starting with Tomcat, `StringTuple` is loaded by ParallelWebappClassLoader, `JacksonSerializer` is loaded by AppClassLoader, so `@JsonProperty("f")` is invalid, I gonna fix with this temporary solution.