### PR TITLE
fix: record servlet request full url

### DIFF
--- a/arex-instrumentation/servlet/arex-httpservlet/src/main/java/io/arex/inst/httpservlet/ServletAdviceHelper.java
+++ b/arex-instrumentation/servlet/arex-httpservlet/src/main/java/io/arex/inst/httpservlet/ServletAdviceHelper.java
@@ -153,10 +153,11 @@ public class ServletAdviceHelper {
             return true;
         }
 
+        String requestURI = adapter.getRequestURI(httpServletRequest);
+
         // Filter invalid servlet path suffix
         if (HTTP_METHOD_GET.equals(adapter.getMethod(httpServletRequest))) {
-            String servletPath = adapter.getServletPath(httpServletRequest);
-            return StringUtil.isEmpty(servletPath) || FILTERED_GET_URL_SUFFIX.stream().anyMatch(servletPath::contains);
+            return StringUtil.isEmpty(requestURI) || FILTERED_GET_URL_SUFFIX.stream().anyMatch(requestURI::contains);
         }
 
         // Filter invalid content-type
@@ -165,12 +166,10 @@ public class ServletAdviceHelper {
             return true;
         }
 
-        String uri = adapter.getRequestURI(httpServletRequest);
-
-        if (IgnoreUtils.ignoreOperation(uri)) {
+        if (IgnoreUtils.ignoreOperation(requestURI)) {
             return true;
         }
 
-        return !RecordLimiter.acquire(uri);
+        return !RecordLimiter.acquire(requestURI);
     }
 }

--- a/arex-instrumentation/servlet/arex-httpservlet/src/main/java/io/arex/inst/httpservlet/ServletExtractor.java
+++ b/arex-instrumentation/servlet/arex-httpservlet/src/main/java/io/arex/inst/httpservlet/ServletExtractor.java
@@ -1,6 +1,7 @@
 package io.arex.inst.httpservlet;
 
 import io.arex.agent.bootstrap.model.Mocker;
+import io.arex.agent.bootstrap.util.StringUtil;
 import io.arex.inst.httpservlet.adapter.ServletAdapter;
 import io.arex.inst.runtime.context.ContextManager;
 import io.arex.inst.runtime.model.ArexConstants;
@@ -70,7 +71,7 @@ public class ServletExtractor<HttpServletRequest, HttpServletResponse> {
 
         Map<String, Object> requestAttributes = new HashMap<>();
         requestAttributes.put("HttpMethod", adapter.getMethod(httpServletRequest));
-        requestAttributes.put("RequestPath", adapter.getServletPath(httpServletRequest));
+        requestAttributes.put("RequestPath", adapter.getFullUrl(httpServletRequest));
         requestAttributes.put("Headers", getRequestHeaders());
 
         Map<String, Object> responseAttributes = Collections.singletonMap("Headers", getResponseHeaders());
@@ -110,7 +111,7 @@ public class ServletExtractor<HttpServletRequest, HttpServletResponse> {
 
     private String getRequest() {
         if ("GET".equals(adapter.getMethod(httpServletRequest))) {
-            return adapter.getQueryString(httpServletRequest);
+            return StringUtil.EMPTY;
         }
         // Compatible with custom message converters that include compression
         return Base64.getEncoder().encodeToString(adapter.getRequestBytes(httpServletRequest));

--- a/arex-instrumentation/servlet/arex-httpservlet/src/main/java/io/arex/inst/httpservlet/adapter/ServletAdapter.java
+++ b/arex-instrumentation/servlet/arex-httpservlet/src/main/java/io/arex/inst/httpservlet/adapter/ServletAdapter.java
@@ -44,7 +44,7 @@ public interface ServletAdapter<HttpServletRequest, HttpServletResponse> {
 
     String getContentType(HttpServletRequest httpServletRequest);
 
-    String getServletPath(HttpServletRequest httpServletRequest);
+    String getFullUrl(HttpServletRequest httpServletRequest);
 
     String getRequestURI(HttpServletRequest httpServletRequest);
 
@@ -53,8 +53,6 @@ public interface ServletAdapter<HttpServletRequest, HttpServletResponse> {
     Enumeration<String> getRequestHeaderNames(HttpServletRequest httpServletRequest);
 
     Collection<String> getResponseHeaderNames(HttpServletResponse httpServletResponse);
-
-    String getQueryString(HttpServletRequest httpServletRequest);
 
     byte[] getRequestBytes(HttpServletRequest httpServletRequest);
 

--- a/arex-instrumentation/servlet/arex-httpservlet/src/main/java/io/arex/inst/httpservlet/adapter/impl/ServletAdapterImplV3.java
+++ b/arex-instrumentation/servlet/arex-httpservlet/src/main/java/io/arex/inst/httpservlet/adapter/impl/ServletAdapterImplV3.java
@@ -98,8 +98,15 @@ public class ServletAdapterImplV3 implements ServletAdapter<HttpServletRequest, 
     }
 
     @Override
-    public String getServletPath(HttpServletRequest httpServletRequest) {
-        return httpServletRequest.getServletPath();
+    public String getFullUrl(HttpServletRequest httpServletRequest) {
+        StringBuilder fullUrl = new StringBuilder(httpServletRequest.getRequestURI());
+        String queryString = httpServletRequest.getQueryString();
+
+        if (queryString == null) {
+            return fullUrl.toString();
+        } else {
+            return fullUrl.append('?').append(queryString).toString();
+        }
     }
 
     @Override
@@ -125,11 +132,6 @@ public class ServletAdapterImplV3 implements ServletAdapter<HttpServletRequest, 
     @Override
     public Collection<String> getResponseHeaderNames(HttpServletResponse httpServletResponse) {
         return httpServletResponse.getHeaderNames();
-    }
-
-    @Override
-    public String getQueryString(HttpServletRequest httpServletRequest) {
-        return httpServletRequest.getQueryString();
     }
 
     @Override

--- a/arex-instrumentation/servlet/arex-httpservlet/src/main/java/io/arex/inst/httpservlet/adapter/impl/ServletAdapterImplV5.java
+++ b/arex-instrumentation/servlet/arex-httpservlet/src/main/java/io/arex/inst/httpservlet/adapter/impl/ServletAdapterImplV5.java
@@ -98,8 +98,15 @@ public class ServletAdapterImplV5 implements ServletAdapter<HttpServletRequest, 
     }
 
     @Override
-    public String getServletPath(HttpServletRequest httpServletRequest) {
-        return httpServletRequest.getServletPath();
+    public String getFullUrl(HttpServletRequest httpServletRequest) {
+        StringBuilder fullUrl = new StringBuilder(httpServletRequest.getRequestURI());
+        String queryString = httpServletRequest.getQueryString();
+
+        if (queryString == null) {
+            return fullUrl.toString();
+        } else {
+            return fullUrl.append('?').append(queryString).toString();
+        }
     }
 
     @Override
@@ -125,11 +132,6 @@ public class ServletAdapterImplV5 implements ServletAdapter<HttpServletRequest, 
     @Override
     public Collection<String> getResponseHeaderNames(HttpServletResponse httpServletResponse) {
         return httpServletResponse.getHeaderNames();
-    }
-
-    @Override
-    public String getQueryString(HttpServletRequest httpServletRequest) {
-        return httpServletRequest.getQueryString();
     }
 
     @Override

--- a/arex-instrumentation/servlet/arex-httpservlet/src/test/java/io/arex/inst/httpservlet/ServletAdviceHelperTest.java
+++ b/arex-instrumentation/servlet/arex-httpservlet/src/test/java/io/arex/inst/httpservlet/ServletAdviceHelperTest.java
@@ -83,7 +83,7 @@ class ServletAdviceHelperTest {
         Runnable mocker5 = () -> {
             Mockito.when(adapter.getRequestHeader(any(), eq(ArexConstants.REPLAY_WARM_UP))).thenReturn("false");
             Mockito.when(adapter.getMethod(any())).thenReturn("GET");
-            Mockito.when(adapter.getServletPath(any())).thenReturn(".png");
+            Mockito.when(adapter.getFullUrl(any())).thenReturn(".png");
         };
         Runnable mocker6 = () -> {
             Mockito.when(adapter.getMethod(any())).thenReturn("POST");


### PR DESCRIPTION
FUll URL example: `http://localhost:8080/commutity/httpClientTest/okHttp?k1=v1&k2=v2`

The URL required for replay is `/commutity/httpClientTest/okHttp?k1=v1&k2=v2`, need to contain `queryString`

request.getContextPath() -> /commutity
request.getServletPath() -> /httpClientTest/okHttp
request.getRequestURI() -> /commutity/httpClientTest/okHttp
request.getQueryString() -> k1=v1&k2=v2

