### PR TITLE
fix: add ForkJoinPool class to executros

### DIFF
--- a/arex-instrumentation/internal/arex-executors/src/main/java/io/arex/inst/executors/ThreadPoolInstrumentation.java
+++ b/arex-instrumentation/internal/arex-executors/src/main/java/io/arex/inst/executors/ThreadPoolInstrumentation.java
@@ -48,6 +48,7 @@ public class ThreadPoolInstrumentation extends TypeInstrumentation {
 
     private List<String> includeExecutors() {
         return asList(
+                "java.util.concurrent.ForkJoinPool",
                 "java.util.concurrent.ThreadPoolExecutor",
                 "java.util.concurrent.AbstractExecutorService",
                 "java.util.concurrent.CompletableFuture$ThreadPerTaskExecutor",

--- a/arex-instrumentation/internal/arex-executors/src/test/java/io/arex/inst/executors/ExecutorsModuleInstrumentationTest.java
+++ b/arex-instrumentation/internal/arex-executors/src/test/java/io/arex/inst/executors/ExecutorsModuleInstrumentationTest.java
@@ -1,0 +1,24 @@
+package io.arex.inst.executors;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ExecutorsModuleInstrumentationTest {
+    ExecutorsModuleInstrumentation module = new ExecutorsModuleInstrumentation();
+
+    @BeforeEach
+    void setUp() {
+    }
+
+    @AfterEach
+    void tearDown() {
+    }
+
+    @Test
+    void instrumentationTypes() {
+        assertEquals(3, module.instrumentationTypes().size());
+    }
+}

--- a/arex-instrumentation/internal/arex-executors/src/test/java/io/arex/inst/executors/ForkJoinTaskInstrumentationTest.java
+++ b/arex-instrumentation/internal/arex-executors/src/test/java/io/arex/inst/executors/ForkJoinTaskInstrumentationTest.java
@@ -1,0 +1,57 @@
+package io.arex.inst.executors;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.arex.agent.bootstrap.ctx.ArexThreadLocal;
+import io.arex.agent.bootstrap.internal.Cache;
+import io.arex.inst.executors.ForkJoinTaskInstrumentation.ConstructorAdvice;
+import io.arex.inst.executors.ForkJoinTaskInstrumentation.ExecAdvice;
+import java.util.concurrent.CountedCompleter;
+import java.util.concurrent.ForkJoinTask;
+import net.bytebuddy.description.type.TypeDescription;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ForkJoinTaskInstrumentationTest {
+
+    ForkJoinTaskInstrumentation inst = new ForkJoinTaskInstrumentation();
+
+    @BeforeEach
+    void setUp() {
+    }
+
+    @AfterEach
+    void tearDown() {
+    }
+
+    @Test
+    void typeMatcher() {
+        boolean matched1 = inst.typeMatcher().matches(TypeDescription.ForLoadedType.of(ForkJoinTask.class));
+        boolean matched2 = inst.typeMatcher().matches(TypeDescription.ForLoadedType.of(CountedCompleter.class));
+        assertTrue(matched1 & matched2);
+    }
+
+    @Test
+    void methodAdvices() {
+        assertEquals(2, inst.methodAdvices().size());
+    }
+
+    @Test
+    void ExecAdvice_onEnter() {
+        Cache.CAPTURED_CACHE.put("fork-test", ArexThreadLocal.Transmitter.capture());
+        assertDoesNotThrow(() -> ExecAdvice.onEnter("fork-test", new Object()));
+    }
+
+    @Test
+    void ExecAdvice_onExit() {
+        assertDoesNotThrow(() -> ExecAdvice.onExit(ArexThreadLocal.Transmitter.capture()));
+    }
+
+    @Test
+    void ConstructorAdvice_onEnter() {
+        assertDoesNotThrow(() -> ConstructorAdvice.onExit(new Object()));
+    }
+}

--- a/arex-instrumentation/internal/arex-executors/src/test/java/io/arex/inst/executors/FutureTaskInstrumentationTest.java
+++ b/arex-instrumentation/internal/arex-executors/src/test/java/io/arex/inst/executors/FutureTaskInstrumentationTest.java
@@ -1,0 +1,49 @@
+package io.arex.inst.executors;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.arex.inst.executors.FutureTaskInstrumentation.CallableAdvice;
+import io.arex.inst.executors.FutureTaskInstrumentation.RunnableAdvice;
+import java.util.concurrent.Callable;
+import java.util.concurrent.FutureTask;
+import net.bytebuddy.description.type.TypeDescription;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class FutureTaskInstrumentationTest {
+
+    FutureTaskInstrumentation inst = new FutureTaskInstrumentation();
+
+    @BeforeEach
+    void setUp() {
+    }
+
+    @AfterEach
+    void tearDown() {
+    }
+
+    @Test
+    void typeMatcher() {
+        assertTrue(inst.typeMatcher().matches(TypeDescription.ForLoadedType.of(FutureTask.class)));
+    }
+
+    @Test
+    void methodAdvices() {
+        assertEquals(2, inst.methodAdvices().size());
+    }
+
+    @Test
+    void CallableAdvice_methodEnter() {
+        Callable<String> callable = () -> "mock-test";
+        assertDoesNotThrow(() -> CallableAdvice.methodEnter(callable));
+    }
+
+    @Test
+    void RunnableAdvice_methodEnter() {
+        Runnable runnable = () -> System.out.println("mock-test");
+        assertDoesNotThrow(() -> RunnableAdvice.methodEnter(runnable));
+    }
+}

--- a/arex-instrumentation/internal/arex-executors/src/test/java/io/arex/inst/executors/ThreadInstrumentationTest.java
+++ b/arex-instrumentation/internal/arex-executors/src/test/java/io/arex/inst/executors/ThreadInstrumentationTest.java
@@ -1,0 +1,45 @@
+package io.arex.inst.executors;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.arex.inst.executors.ThreadInstrumentation.StartAdvice;
+import io.arex.inst.runtime.context.ArexContext;
+import io.arex.inst.runtime.context.ContextManager;
+import net.bytebuddy.description.type.TypeDescription;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class ThreadInstrumentationTest {
+    ThreadInstrumentation inst = new ThreadInstrumentation();
+
+    @BeforeAll
+    static void setUp() {
+        Mockito.mockStatic(ContextManager.class);
+    }
+
+    @AfterAll
+    static void tearDown() {
+        Mockito.clearAllCaches();
+    }
+
+    @Test
+    void typeMatcher() {
+        assertTrue(inst.typeMatcher().matches(TypeDescription.ForLoadedType.of(Thread.class)));
+    }
+
+    @Test
+    void methodAdvices() {
+        assertEquals(1, inst.methodAdvices().size());
+    }
+
+    @Test
+    void StartAdvice_methodEnter() {
+        Mockito.when(ContextManager.currentContext()).thenReturn(ArexContext.of("mock-case-id"));
+        Runnable runnable = () -> System.out.println("mock-test");
+        assertDoesNotThrow(() -> StartAdvice.methodEnter(runnable));
+    }
+}

--- a/arex-instrumentation/internal/arex-executors/src/test/java/io/arex/inst/executors/ThreadPoolInstrumentationTest.java
+++ b/arex-instrumentation/internal/arex-executors/src/test/java/io/arex/inst/executors/ThreadPoolInstrumentationTest.java
@@ -1,0 +1,50 @@
+package io.arex.inst.executors;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.arex.inst.executors.ThreadPoolInstrumentation.ExecutorCallableAdvice;
+import io.arex.inst.executors.ThreadPoolInstrumentation.ExecutorRunnableAdvice;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ThreadPoolExecutor;
+import net.bytebuddy.description.type.TypeDescription;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ThreadPoolInstrumentationTest {
+    ThreadPoolInstrumentation inst = new ThreadPoolInstrumentation();
+
+    @BeforeEach
+    void setUp() {
+    }
+
+    @AfterEach
+    void tearDown() {
+    }
+
+    @Test
+    void typeMatcher() {
+        assertTrue(inst.typeMatcher().matches(TypeDescription.ForLoadedType.of(ForkJoinPool.class)));
+        assertTrue(inst.typeMatcher().matches(TypeDescription.ForLoadedType.of(ThreadPoolExecutor.class)));
+    }
+
+    @Test
+    void methodAdvices() {
+        assertEquals(2, inst.methodAdvices().size());
+    }
+
+    @Test
+    void ExecutorCallableAdvice_methodEnter() {
+        Callable<String> callable = () -> "mock-test";
+        assertDoesNotThrow(() -> ExecutorCallableAdvice.methodEnter(callable));
+    }
+
+    @Test
+    void ExecutorRunnableAdvice_methodEnter() {
+        Runnable runnable = () -> System.out.println("mock-test");
+        assertDoesNotThrow(() -> ExecutorRunnableAdvice.methodEnter(runnable));
+    }
+}


### PR DESCRIPTION
Support ForkJoinPool missing retransformed methods:

```java
java.util.concurrent.ForkJoinPool#execute(java.lang.Runnable)
java.util.concurrent.ForkJoinPool#submit(java.lang.Runnable, T)
java.util.concurrent.ForkJoinPool#submit(java.lang.Runnable)

java.util.concurrent.ForkJoinPool#submit(java.util.concurrent.Callable<T>)
```