### PR TITLE
fix: get request bytes from GzipCompressingEntity

### DIFF
--- a/arex-instrumentation/httpclient/arex-httpclient-apache-v4/src/main/java/io/arex/inst/httpclient/apache/common/ApacheHttpClientHelper.java
+++ b/arex-instrumentation/httpclient/arex-httpclient-apache-v4/src/main/java/io/arex/inst/httpclient/apache/common/ApacheHttpClientHelper.java
@@ -9,10 +9,6 @@ import org.apache.http.message.ParserCursor;
 import org.apache.http.protocol.HTTP;
 import org.apache.http.util.CharArrayBuffer;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Arrays;
-
 class ApacheHttpClientHelper {
 
     public static BasicHttpEntity createHttpEntity(HttpResponse response) {
@@ -39,31 +35,5 @@ class ApacheHttpClientHelper {
         final CharArrayBuffer buffer = convertToBuffer(statusLine);
         final ParserCursor cursor = new ParserCursor(0, buffer.length());
         return BasicLineParser.INSTANCE.parseStatusLine(buffer, cursor);
-    }
-
-    public static byte[] readInputStream(InputStream in) throws IOException {
-        byte[] buffer = new byte[0];
-
-        int read;
-        int stepSize = 1024;
-        for(int i = 0; i < Integer.MAX_VALUE; i += read) {
-            if (i >= buffer.length) {
-                if (buffer.length < i + stepSize) {
-                    buffer = Arrays.copyOf(buffer, i + stepSize);
-                }
-            } else {
-                stepSize = buffer.length - i;
-            }
-
-            read = in.read(buffer, i, stepSize);
-            if (read < 0) {
-                if (buffer.length != i) {
-                    buffer = Arrays.copyOf(buffer, i);
-                }
-                break;
-            }
-        }
-
-        return buffer;
     }
 }

--- a/arex-instrumentation/httpclient/arex-httpclient-apache-v4/src/main/java/io/arex/inst/httpclient/apache/sync/InternalHttpClientInstrumentation.java
+++ b/arex-instrumentation/httpclient/arex-httpclient-apache-v4/src/main/java/io/arex/inst/httpclient/apache/sync/InternalHttpClientInstrumentation.java
@@ -45,7 +45,10 @@ public class InternalHttpClientInstrumentation extends TypeInstrumentation {
                 "io.arex.inst.httpclient.common.HttpClientExtractor",
                 "io.arex.inst.httpclient.apache.common.ApacheHttpClientAdapter",
                 "io.arex.inst.httpclient.apache.common.ApacheHttpClientHelper",
-                "io.arex.inst.httpclient.common.HttpClientAdapter");
+                "io.arex.inst.httpclient.common.HttpClientAdapter",
+                "io.arex.inst.httpclient.apache.common.CloseableHttpResponseProxy",
+                "io.arex.inst.httpclient.common.HttpResponseWrapper",
+                "io.arex.inst.httpclient.common.HttpResponseWrapper$StringTuple");
     }
 
     public static class ExecuteAdvice {

--- a/arex-instrumentation/httpclient/arex-httpclient-apache-v4/src/test/java/io/arex/inst/httpclient/apache/async/InternalHttpAsyncClientInstrumentationTest.java
+++ b/arex-instrumentation/httpclient/arex-httpclient-apache-v4/src/test/java/io/arex/inst/httpclient/apache/async/InternalHttpAsyncClientInstrumentationTest.java
@@ -1,6 +1,7 @@
 package io.arex.inst.httpclient.apache.async;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mockStatic;
@@ -44,7 +45,7 @@ class InternalHttpAsyncClientInstrumentationTest {
 
     @Test
     void adviceClassNames() {
-        assertNotNull(target.adviceClassNames());
+        assertEquals(8, target.adviceClassNames().size());
     }
 
     @Test

--- a/arex-instrumentation/httpclient/arex-httpclient-apache-v4/src/test/java/io/arex/inst/httpclient/apache/sync/InternalHttpClientInstrumentationTest.java
+++ b/arex-instrumentation/httpclient/arex-httpclient-apache-v4/src/test/java/io/arex/inst/httpclient/apache/sync/InternalHttpClientInstrumentationTest.java
@@ -50,7 +50,7 @@ class InternalHttpClientInstrumentationTest {
 
     @Test
     void adviceClassNames() {
-        assertNotNull(target.adviceClassNames());
+        assertEquals(7, target.adviceClassNames().size());
     }
 
     @Test

--- a/arex-instrumentation/httpclient/arex-httpclient-common/src/main/java/io/arex/inst/httpclient/common/HttpClientAdapter.java
+++ b/arex-instrumentation/httpclient/arex-httpclient-common/src/main/java/io/arex/inst/httpclient/common/HttpClientAdapter.java
@@ -3,6 +3,7 @@ package io.arex.inst.httpclient.common;
 import java.net.URI;
 
 public interface HttpClientAdapter<TRequest, TResponse> {
+    byte[] ZERO_BYTE = new byte[0];
     String CONTENT_TYPE_NAME = "Content-Type";
     String USER_AGENT_NAME = "User-Agent";
 


### PR DESCRIPTION
## The problem stacktrace is as follows

```text
failed: java.lang.UnsupportedOperationException
	at org.apache.http.client.entity.GzipCompressingEntity.getContent(GzipCompressingEntity.java:100)
	at org.apache.http.util.EntityUtils.toByteArray(EntityUtils.java:122)
	at io.arex.inst.httpclient.apache.common.ApacheHttpClientAdapter.getRequestBytes(ApacheHttpClientAdapter.java:52)
	at io.arex.inst.httpclient.common.HttpClientExtractor.encodeRequest(HttpClientExtractor.java:82)
	at io.arex.inst.httpclient.common.HttpClientExtractor.makeMocker(HttpClientExtractor.java:76)
	at io.arex.inst.httpclient.common.HttpClientExtractor.record(HttpClientExtractor.java:40)
	at org.apache.http.impl.client.InternalHttpClient.doExecute(InternalHttpClient.java:186)
	at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:82)
	at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:107)
```

## Test coverage after fix
### apache http client record & replay 
1. sync client call with normal request bytes √.
2. sync client call with gzip request bytes √.
3. async client call with normal request bytes √.
4. async client call with gzip request bytes ×, cause [HttpAsyncClient 4.1 and 5.0 do not support automatic content
compression / decompression. This feature is supported by classic
(blocking) i/o only.](https://httpclient-users.hc.apache.narkive.com/G0FNB90x/async-client-and-gzip-request-unsupportedoperationexception)

