### PR TITLE
feat: support Random#nextInt mock and support UUID/currentTime in constructor

### DIFF
--- a/arex-instrumentation-api/src/main/java/io/arex/inst/runtime/model/ArexConstants.java
+++ b/arex-instrumentation-api/src/main/java/io/arex/inst/runtime/model/ArexConstants.java
@@ -22,4 +22,5 @@ public class ArexConstants {
 
     public static final String UUID_SIGNATURE = "java.util.UUID.randomUUID";
     public static final String CURRENT_TIME_MILLIS_SIGNATURE = "java.lang.System.currentTimeMillis";
+    public static final String NEXT_INT_SIGNATURE = "java.util.Random.nextInt";
 }

--- a/arex-instrumentation-api/src/main/java/io/arex/inst/runtime/model/DynamicClassEntity.java
+++ b/arex-instrumentation-api/src/main/java/io/arex/inst/runtime/model/DynamicClassEntity.java
@@ -60,7 +60,9 @@ public class DynamicClassEntity {
     }
 
     private boolean isReplaceMethodSignature(String keyFormula) {
-        return ArexConstants.UUID_SIGNATURE.equals(keyFormula) || ArexConstants.CURRENT_TIME_MILLIS_SIGNATURE.equals(keyFormula);
+        return ArexConstants.UUID_SIGNATURE.equals(keyFormula) ||
+               ArexConstants.CURRENT_TIME_MILLIS_SIGNATURE.equals(keyFormula) ||
+               ArexConstants.NEXT_INT_SIGNATURE.equals(keyFormula);
     }
 
     public String getSignature() {

--- a/arex-instrumentation/dynamic/arex-dynamic/src/main/java/io/arex/inst/dynamic/ReplaceMethodHelper.java
+++ b/arex-instrumentation/dynamic/arex-dynamic/src/main/java/io/arex/inst/dynamic/ReplaceMethodHelper.java
@@ -4,11 +4,13 @@ import io.arex.agent.bootstrap.cache.TimeCache;
 import io.arex.agent.bootstrap.util.StringUtil;
 import io.arex.inst.runtime.context.ContextManager;
 import io.arex.agent.bootstrap.model.Mocker;
-
+import io.arex.inst.runtime.util.LogUtil;
 import io.arex.inst.runtime.util.MockUtils;
+import java.util.Random;
 import java.util.UUID;
 
 public class ReplaceMethodHelper {
+    private static final String STRING_TYPE_NAME = String.class.getName();
 
     public static long currentTimeMillis() {
         if (ContextManager.needReplay()) {
@@ -24,21 +26,48 @@ public class ReplaceMethodHelper {
     public static UUID uuid() {
         if (ContextManager.needReplay()) {
             Mocker mocker = createMocker();
-            return UUID.fromString(String.valueOf(MockUtils.replayBody(mocker)));
+            Mocker replayMocker = MockUtils.replayMocker(mocker);
+            return UUID.fromString(replayMocker.getTargetResponse().getBody());
         }
         UUID realUuid = UUID.randomUUID();
         if (ContextManager.needRecord()) {
             Mocker mocker = createMocker();
-            mocker.getTargetResponse().setType(String.class.getName());
+            mocker.getTargetResponse().setType(STRING_TYPE_NAME);
             mocker.getTargetResponse().setBody(realUuid.toString());
             MockUtils.recordMocker(mocker);
         }
         return realUuid;
     }
 
+    public static int nextInt(Object random, int bound) {
+        if (ContextManager.needReplay()) {
+            Mocker mocker = createNextIntMocker(bound);
+            Mocker replayMocker = MockUtils.replayMocker(mocker);
+            return Integer.parseInt(replayMocker.getTargetResponse().getBody());
+        }
+        int realNextInt = ((Random)random).nextInt(bound);
+        try {
+            if (ContextManager.needRecord()) {
+                Mocker mocker = createNextIntMocker(bound);
+                mocker.getTargetResponse().setBody(String.valueOf(realNextInt));
+                mocker.getTargetResponse().setType(STRING_TYPE_NAME);
+                MockUtils.recordMocker(mocker);
+            }
+        } catch (Throwable ex) {
+            LogUtil.warn("replaceNextIntRecord", ex);
+        }
+        return realNextInt;
+    }
+
     private static Mocker createMocker() {
         Mocker mocker = MockUtils.createDynamicClass(UUID.class.getName(), "randomUUID");
         mocker.getTargetRequest().setBody(StringUtil.EMPTY);
+        return mocker;
+    }
+
+    private static Mocker createNextIntMocker(int bound) {
+        Mocker mocker = MockUtils.createDynamicClass(Random.class.getName(), "nextInt");
+        mocker.getTargetRequest().setBody(String.valueOf(bound));
         return mocker;
     }
 }

--- a/arex-instrumentation/dynamic/arex-dynamic/src/test/java/io/arex/inst/dynamic/ReplaceMethodClass.java
+++ b/arex-instrumentation/dynamic/arex-dynamic/src/test/java/io/arex/inst/dynamic/ReplaceMethodClass.java
@@ -1,0 +1,26 @@
+package io.arex.inst.dynamic;
+
+import java.util.Random;
+import java.util.UUID;
+
+public class ReplaceMethodClass {
+    public static final Random random = new Random();
+    public long currentTimeMillis() {
+        long timeMillis = System.currentTimeMillis();
+        System.out.println("currentTimeMillis: " + timeMillis);
+        return timeMillis;
+    }
+
+    public String uuid() {
+        String uuid = UUID.randomUUID().toString();
+        System.out.println("uuid: " + uuid);
+        return uuid;
+    }
+
+
+    public int nextInt() {
+        int nextInt = random.nextInt(10);
+        System.out.println("nextInt: " + nextInt);
+        return nextInt;
+    }
+}

--- a/arex-instrumentation/dynamic/arex-dynamic/src/test/java/io/arex/inst/dynamic/ReplaceMethodHelperTest.java
+++ b/arex-instrumentation/dynamic/arex-dynamic/src/test/java/io/arex/inst/dynamic/ReplaceMethodHelperTest.java
@@ -1,0 +1,92 @@
+package io.arex.inst.dynamic;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.arex.agent.bootstrap.cache.TimeCache;
+import io.arex.agent.bootstrap.model.ArexMocker;
+import io.arex.agent.bootstrap.model.Mocker;
+import io.arex.inst.runtime.context.ContextManager;
+import io.arex.inst.runtime.context.RepeatedCollectManager;
+import io.arex.inst.runtime.util.MockUtils;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+
+class ReplaceMethodHelperTest {
+    static ArexMocker mocker = null;
+    @BeforeAll
+    static void setUp() {
+        Mockito.mockStatic(ContextManager.class);
+        Mockito.mockStatic(RepeatedCollectManager.class);
+        Mockito.mockStatic(MockUtils.class);
+        Mockito.mockStatic(TimeCache.class);
+        mocker = new ArexMocker();
+        mocker.setTargetRequest(new Mocker.Target());
+        mocker.setTargetResponse(new Mocker.Target());
+    }
+
+    @AfterAll
+    static void tearDown() {
+        mocker = null;
+        Mockito.clearAllCaches();
+    }
+
+    @Test
+    void testUuidReplay() {
+        Mockito.when(ContextManager.needReplay()).thenReturn(true);
+        mocker.getTargetResponse().setBody("7eb4f958-671a-11ed-9022-0242ac120002");
+        Mockito.when(MockUtils.replayMocker(any())).thenReturn(mocker);
+        Mockito.when(MockUtils.createDynamicClass(any(), any())).thenReturn(mocker);
+        UUID uuid = ReplaceMethodHelper.uuid();
+        Assertions.assertEquals("7eb4f958-671a-11ed-9022-0242ac120002", uuid.toString());
+    }
+
+    @Test
+    void testUuidRecord() {
+        Mockito.when(ContextManager.needReplay()).thenReturn(false);
+        Mockito.when(ContextManager.needRecord()).thenReturn(true);
+        Mockito.when(MockUtils.createDynamicClass(any(), any())).thenReturn(mocker);
+        Assertions.assertDoesNotThrow(ReplaceMethodHelper::uuid);
+    }
+
+    @Test
+    void testNextReplay() {
+        Mockito.when(ContextManager.needReplay()).thenReturn(true);
+        mocker.getTargetResponse().setBody("2");
+        Mockito.when(MockUtils.replayMocker(any())).thenReturn(mocker);
+        Mockito.when(MockUtils.createDynamicClass(any(), any())).thenReturn(mocker);
+        int nextInt = ReplaceMethodHelper.nextInt(new Random(), 10);
+        Assertions.assertEquals(2, nextInt);
+    }
+
+    @Test
+    void testNextIntRecord() {
+        Mockito.when(ContextManager.needReplay()).thenReturn(false);
+        Mockito.when(ContextManager.needRecord()).thenReturn(true);
+        Mockito.when(MockUtils.createDynamicClass(any(), any())).thenReturn(mocker);
+        Assertions.assertDoesNotThrow(() -> ReplaceMethodHelper.nextInt(new Random(), 10));
+    }
+
+    @Test
+    void testSystemReplay() {
+        Mockito.when(ContextManager.needReplay()).thenReturn(true);
+        Mockito.when(TimeCache.get()).thenReturn(2L);
+        long replayTime = ReplaceMethodHelper.currentTimeMillis();
+        Assertions.assertEquals(2, replayTime);
+    }
+
+    @Test
+    void testSystemRecord() {
+        Mockito.when(ContextManager.needReplay()).thenReturn(false);
+        Mockito.when(ContextManager.needRecord()).thenReturn(true);
+        Assertions.assertDoesNotThrow(ReplaceMethodHelper::currentTimeMillis);
+    }
+}


### PR DESCRIPTION
The use of uuid/nextInt exists in the application code and has an impact on the subsequent logic.
If the mock `UUID.randomUUID()/Random.nextInt()` method cannot control the modification range,
it is easy to record a large amount of useless data. 
Therefore, the `UUID.randomUUID()/Random.nextInt()`  in the method configured by the user 
is searched for using logic and replaced, so as to achieve the effect of recording the uuid 
in the specified method.

ex: UUID Demo :
```java
package com.ctrip.flight.test.service;
public class TestService {
  public void testDemo(String s) {
    ...
    String transId = UUID.randomUUID().toString();
    ...
  }
}
```

Dynamic class configuration:
FullClassName : com.ctrip.flight.test.service.TestService
MethodName : testDemo
ParameterTypes : java.lang.String
keyFormula : java.util.UUID.randomUUID

after replace:
```java
package com.ctrip.flight.test.service;
public class TestService {
  public void testDemo(String s) {
    ...
    String transId = ReplaceMethodHelper.uuid().toString();
    ...
  }
```
}
