### PR TITLE
feat: support for dynamic class config using wildcards and abstract class

### DIFF
--- a/arex-instrumentation/dynamic/arex-dynamic/src/test/java/io/arex/inst/dynamic/AbstractDynamicTestClass.java
+++ b/arex-instrumentation/dynamic/arex-dynamic/src/test/java/io/arex/inst/dynamic/AbstractDynamicTestClass.java
@@ -1,0 +1,5 @@
+package io.arex.inst.dynamic;
+
+public abstract class AbstractDynamicTestClass {
+
+}

--- a/arex-instrumentation/dynamic/arex-dynamic/src/test/java/io/arex/inst/dynamic/DynamicTestClass.java
+++ b/arex-instrumentation/dynamic/arex-dynamic/src/test/java/io/arex/inst/dynamic/DynamicTestClass.java
@@ -2,7 +2,7 @@ package io.arex.inst.dynamic;
 
 import java.util.UUID;
 
-public class DynamicTestClass {
+public class DynamicTestClass extends AbstractDynamicTestClass {
 
     public long testReturnPrimitiveType() {
         long timeMillis = System.currentTimeMillis();


### PR DESCRIPTION
Support for dynamic class config using wildcards and abstract class
- infix: `io.arex.inst.dynamic.*namicTest*`
- suffix: `io.arex.inst.dynamic.*namicTestClass`
- prefix: `io.arex.inst.dynamic.DynamicTest*`
- equals: `io.arex.inst.dynamic.DynamicTestClass`
- abstract class or interface: `ac:io.arex.inst.dynamic.AbstractDynamicTestClass`