### PR TITLE
fix: record servlet request redirect

### DIFF
--- a/arex-agent-bootstrap/src/main/java/io/arex/agent/bootstrap/model/Mocker.java
+++ b/arex-agent-bootstrap/src/main/java/io/arex/agent/bootstrap/model/Mocker.java
@@ -1,5 +1,6 @@
 package io.arex.agent.bootstrap.model;
 
+import io.arex.agent.bootstrap.util.StringUtil;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
@@ -89,5 +90,22 @@ public interface Mocker extends Serializable {
         public void setType(String type) {
             this.type = type;
         }
+    }
+
+    default StringBuilder logBuilder() {
+        StringBuilder builder = new StringBuilder("[arex]");
+        boolean isReplay = StringUtil.isNotEmpty(getReplayId());
+        if (isReplay) {
+            builder.append("replay");
+        } else {
+            builder.append("record");
+        }
+        builder.append(" category: ").append(getCategoryType().getName());
+        builder.append(", operation: ").append(getOperationName());
+        builder.append(", recordId: ").append(getRecordId());
+        if (isReplay) {
+            builder.append(", replayId: ").append(getReplayId());
+        }
+        return builder;
     }
 }

--- a/arex-agent-core/src/test/java/io/arex/agent/instrumentation/InstrumentationInstallerTest.java
+++ b/arex-agent-core/src/test/java/io/arex/agent/instrumentation/InstrumentationInstallerTest.java
@@ -119,6 +119,5 @@ class InstrumentationInstallerTest {
         DynamicType dynamicType = Mockito.mock(DynamicType.class);
         listener.onTransformation(typeDescription, null, null, false, dynamicType);
         verify(dynamicType).saveIn(any());
-        listener.onError(null, null,null, false, null);
     }
 }

--- a/arex-instrumentation-api/src/main/java/io/arex/inst/runtime/context/ContextManager.java
+++ b/arex-instrumentation-api/src/main/java/io/arex/inst/runtime/context/ContextManager.java
@@ -51,6 +51,10 @@ public class ContextManager {
         return RECORD_MAP.get(traceId);
     }
 
+    public static ArexContext getRecordContext(String recordId) {
+        return RECORD_MAP.get(recordId);
+    }
+
     public static boolean needRecord() {
         ArexContext context = currentContext();
         return context != null && !context.isReplay();

--- a/arex-instrumentation-api/src/main/java/io/arex/inst/runtime/model/ArexConstants.java
+++ b/arex-instrumentation-api/src/main/java/io/arex/inst/runtime/model/ArexConstants.java
@@ -7,6 +7,9 @@ public class ArexConstants {
     public static final String REPLAY_ID = "arex-replay-id";
     public static final String REPLAY_WARM_UP = "arex-replay-warm-up";
     public static final String FORCE_RECORD = "arex-force-record";
+    public static final String REDIRECT_REQUEST_METHOD = "arex-redirect-request-method";
+    public static final String REDIRECT_REFERER = "arex-redirect-referer";
+    public static final String REDIRECT_PATTERN = "arex-redirect-pattern";
     /**
      * mock template
      */

--- a/arex-instrumentation-api/src/main/java/io/arex/inst/runtime/util/MockUtils.java
+++ b/arex-instrumentation-api/src/main/java/io/arex/inst/runtime/util/MockUtils.java
@@ -17,6 +17,8 @@ import org.slf4j.LoggerFactory;
 
 public final class MockUtils {
 
+    private static final String EMPTY_JSON = "{}";
+
     private MockUtils() {
     }
 
@@ -87,6 +89,11 @@ public final class MockUtils {
 
     public static void recordMocker(Mocker requestMocker) {
         String postJson = Serializer.serialize(requestMocker);
+
+        if (Config.get().isEnableDebug()) {
+            LOGGER.info("{}\nrequest: {}", requestMocker.logBuilder(), postJson);
+        }
+
         DataService.INSTANCE.save(postJson);
     }
 
@@ -96,8 +103,14 @@ public final class MockUtils {
 
     public static Mocker replayMocker(Mocker requestMocker, MockStrategyEnum mockStrategy) {
         String postJson = Serializer.serialize(requestMocker);
+
         String data = DataService.INSTANCE.query(postJson, mockStrategy);
-        if (StringUtil.isEmpty(data) || "{}".equals(data)) {
+
+        if (Config.get().isEnableDebug()) {
+            LOGGER.info("{}\nrequest: {}\nresponse: {}", requestMocker.logBuilder(), postJson, data);
+        }
+
+        if (StringUtil.isEmpty(data) || EMPTY_JSON.equals(data)) {
             LOGGER.warn("[arex] response body is null. request: {}", postJson);
             return null;
         }

--- a/arex-instrumentation-foundation/src/main/java/io/arex/foundation/services/DataCollectorService.java
+++ b/arex-instrumentation-foundation/src/main/java/io/arex/foundation/services/DataCollectorService.java
@@ -106,9 +106,6 @@ public class DataCollectorService implements DataCollector {
     }
 
     void saveData(DataEntity entity) {
-        if (ConfigManager.INSTANCE.isEnableDebug()) {
-            LOGGER.info("[arex] save mocker: {}", entity.getPostData());
-        }
         AsyncHttpClientUtil.executeAsync(saveApiUrl, entity.getPostData()).whenComplete(saveMockDataConsumer(entity));
     }
 

--- a/arex-instrumentation/servlet/arex-httpservlet/src/main/java/io/arex/inst/httpservlet/ServletAdviceHelper.java
+++ b/arex-instrumentation/servlet/arex-httpservlet/src/main/java/io/arex/inst/httpservlet/ServletAdviceHelper.java
@@ -1,9 +1,11 @@
 package io.arex.inst.httpservlet;
 
+import io.arex.agent.bootstrap.TraceContextManager;
 import io.arex.agent.bootstrap.internal.Pair;
 import io.arex.agent.bootstrap.util.StringUtil;
 import io.arex.inst.httpservlet.adapter.ServletAdapter;
 import io.arex.inst.runtime.config.Config;
+import io.arex.inst.runtime.context.ArexContext;
 import io.arex.inst.runtime.context.ContextManager;
 import io.arex.inst.runtime.listener.CaseEvent;
 import io.arex.inst.runtime.listener.CaseEventDispatcher;
@@ -11,9 +13,7 @@ import io.arex.inst.runtime.listener.EventSource;
 import io.arex.inst.runtime.model.ArexConstants;
 import io.arex.inst.runtime.util.IgnoreUtils;
 import io.arex.inst.runtime.util.LogUtil;
-import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
@@ -31,7 +31,6 @@ public class ServletAdviceHelper {
     public static final String SERVLET_RESPONSE = "arex-servlet-response";
     private static final Set<String> FILTERED_CONTENT_TYPE = new HashSet<>();
     private static final Set<String> FILTERED_GET_URL_SUFFIX = new HashSet<>();
-    private static final List<Integer> RESPONSE_STATUS_LIST = new ArrayList<>();
     public static final String PROCESSED_FLAG = "arex-processed-flag";
 
     static {
@@ -48,9 +47,6 @@ public class ServletAdviceHelper {
         FILTERED_GET_URL_SUFFIX.add(".pdf");
         FILTERED_GET_URL_SUFFIX.add(".map");
         FILTERED_GET_URL_SUFFIX.add(".ico");
-
-        RESPONSE_STATUS_LIST.add(200);
-        RESPONSE_STATUS_LIST.add(302);
     }
 
     /**
@@ -81,29 +77,39 @@ public class ServletAdviceHelper {
         if (httpServletRequest == null) {
             return null;
         }
+
         // This judgment prevents multiple calls (although there are multiple calls in a request, only one pass is allowed)
         if (adapter.markProcessed(httpServletRequest, PROCESSED_FLAG)) {
             return null;
         }
+
         TResponse httpServletResponse = adapter.asHttpServletResponse(servletResponse);
         if (httpServletResponse == null) {
             return null;
         }
 
         // Async listener will handle if attr with arex-async-flag
-        if (Boolean.TRUE.toString().equals(adapter.getAttribute(httpServletRequest, SERVLET_ASYNC_FLAG))) {
-            httpServletResponse = adapter.wrapResponse(httpServletResponse);
-            return Pair.of(null, httpServletResponse);
+        if (Boolean.TRUE.equals(adapter.getAttribute(httpServletRequest, SERVLET_ASYNC_FLAG))) {
+            return null;
         }
 
-        CaseEventDispatcher.onEvent(CaseEvent.ofEnterEvent());
         if (shouldSkip(adapter, httpServletRequest)) {
             return null;
         }
 
-        String caseId = adapter.getRequestHeader(httpServletRequest, ArexConstants.RECORD_ID);
-        String excludeMockTemplate = adapter.getRequestHeader(httpServletRequest, ArexConstants.HEADER_EXCLUDE_MOCK);
-        CaseEventDispatcher.onEvent(CaseEvent.ofCreateEvent(EventSource.of(caseId, excludeMockTemplate)));
+        // 302 Redirect request
+        String redirectRecordId = getRedirectRecordId(adapter, httpServletRequest);
+        if (StringUtil.isNotEmpty(redirectRecordId)) {
+            TraceContextManager.set(redirectRecordId);
+        }
+
+        if (ContextManager.currentContext() == null) {
+            CaseEventDispatcher.onEvent(CaseEvent.ofEnterEvent());
+            String caseId = adapter.getRequestHeader(httpServletRequest, ArexConstants.RECORD_ID);
+            String excludeMockTemplate = adapter.getRequestHeader(httpServletRequest, ArexConstants.HEADER_EXCLUDE_MOCK);
+            CaseEventDispatcher.onEvent(CaseEvent.ofCreateEvent(EventSource.of(caseId, excludeMockTemplate)));
+        }
+
         if (ContextManager.needRecordOrReplay()) {
             httpServletRequest = adapter.wrapRequest(httpServletRequest);
             httpServletResponse = adapter.wrapResponse(httpServletResponse);
@@ -112,7 +118,6 @@ public class ServletAdviceHelper {
 
         return null;
     }
-
 
     public static <TRequest, TResponse> void onServiceExit(
             ServletAdapter<TRequest, TResponse> adapter, Object servletRequest,
@@ -136,23 +141,14 @@ public class ServletAdviceHelper {
                 return;
             }
 
-            // Do not record if response status is not OK or REDIRECTION
-            int statusCode = adapter.getStatus(httpServletResponse);
-            if (!RESPONSE_STATUS_LIST.contains(statusCode)) {
-                adapter.copyBodyToResponse(httpServletResponse);
-                return;
-            }
-
             // Async listener will handle async request
-            if (Boolean.TRUE.toString().equals(adapter.getAttribute(httpServletRequest, SERVLET_ASYNC_FLAG))) {
-                adapter.removeAttribute(httpServletRequest, SERVLET_ASYNC_FLAG);
-                adapter.copyBodyToResponse(httpServletResponse);
+            if (Boolean.TRUE.equals(adapter.getAttribute(httpServletRequest, SERVLET_ASYNC_FLAG))) {
                 return;
             }
 
             // Add async listener for async request
             if (adapter.isAsyncStarted(httpServletRequest)) {
-                adapter.setAttribute(httpServletRequest, SERVLET_ASYNC_FLAG, Boolean.TRUE.toString());
+                adapter.setAttribute(httpServletRequest, SERVLET_ASYNC_FLAG, Boolean.TRUE);
                 adapter.addListener(adapter, httpServletRequest, httpServletResponse);
                 return;
             }
@@ -232,5 +228,26 @@ public class ServletAdviceHelper {
         }
 
         return Config.get().invalidRecord(requestURI);
+    }
+
+    private static <TRequest, TResponse> String getRedirectRecordId(ServletAdapter<TRequest, TResponse> adapter,
+        TRequest httpServletRequest) {
+        String redirectRecordId = adapter.getParameter(httpServletRequest, ArexConstants.RECORD_ID);
+        if (StringUtil.isEmpty(redirectRecordId)) {
+            return null;
+        }
+
+        String referer = adapter.getRequestHeader(httpServletRequest, "referer");
+
+        if (StringUtil.isEmpty(referer)) {
+            return null;
+        }
+
+        ArexContext context = ContextManager.getRecordContext(redirectRecordId);
+        if (context.isRedirectRequest(referer)) {
+            return redirectRecordId;
+        }
+
+        return null;
     }
 }

--- a/arex-instrumentation/servlet/arex-httpservlet/src/main/java/io/arex/inst/httpservlet/ServletUtil.java
+++ b/arex-instrumentation/servlet/arex-httpservlet/src/main/java/io/arex/inst/httpservlet/ServletUtil.java
@@ -1,0 +1,43 @@
+package io.arex.inst.httpservlet;
+
+import io.arex.agent.bootstrap.util.StringUtil;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+public class ServletUtil {
+
+    private ServletUtil() {
+    }
+
+    public static String appendUri(String uri, String name, String value) {
+        try {
+            URI oldUri = URI.create(uri);
+            StringBuilder builder = new StringBuilder();
+            String newQuery = oldUri.getQuery();
+            if (oldUri.getQuery() == null) {
+                builder.append(name).append("=").append(value);
+            } else {
+                builder.append(newQuery).append("&").append(name).append("=").append(value);
+            }
+
+            URI newUri = new URI(oldUri.getScheme(), oldUri.getAuthority(),
+                oldUri.getPath(), builder.toString(), oldUri.getFragment());
+            return newUri.toString();
+        } catch (URISyntaxException e) {
+            return uri;
+        }
+    }
+
+    public static String getRequestPath(String uri) {
+        try {
+            URI oldUri = URI.create(uri);
+            if (StringUtil.isEmpty(oldUri.getQuery())) {
+                return oldUri.getPath();
+            } else {
+                return new StringBuilder(oldUri.getPath()).append('?').append(oldUri.getQuery()).toString();
+            }
+        } catch (Exception e) {
+            return uri;
+        }
+    }
+}

--- a/arex-instrumentation/servlet/arex-httpservlet/src/main/java/io/arex/inst/httpservlet/adapter/ServletAdapter.java
+++ b/arex-instrumentation/servlet/arex-httpservlet/src/main/java/io/arex/inst/httpservlet/adapter/ServletAdapter.java
@@ -46,7 +46,11 @@ public interface ServletAdapter<HttpServletRequest, HttpServletResponse> {
 
     String getFullUrl(HttpServletRequest httpServletRequest);
 
+    String getRequestPath(HttpServletRequest httpServletRequest);
+
     String getRequestURI(HttpServletRequest httpServletRequest);
+
+    String getPattern(HttpServletRequest httpServletRequest);
 
     String getMethod(HttpServletRequest httpServletRequest);
 
@@ -63,4 +67,6 @@ public interface ServletAdapter<HttpServletRequest, HttpServletResponse> {
     HttpServletResponse asHttpServletResponse(Object servletResponse);
 
     boolean markProcessed(HttpServletRequest httpServletRequest, String mark);
+
+    String getParameter(HttpServletRequest httpServletRequest, String name);
 }

--- a/arex-instrumentation/servlet/arex-httpservlet/src/main/java/io/arex/inst/httpservlet/adapter/impl/ServletAdapterImplV3.java
+++ b/arex-instrumentation/servlet/arex-httpservlet/src/main/java/io/arex/inst/httpservlet/adapter/impl/ServletAdapterImplV3.java
@@ -37,11 +37,17 @@ public class ServletAdapterImplV3 implements ServletAdapter<HttpServletRequest, 
 
     @Override
     public HttpServletRequest wrapRequest(HttpServletRequest httpServletRequest) {
+        if (httpServletRequest instanceof CachedBodyRequestWrapperV3) {
+            return httpServletRequest;
+        }
         return new CachedBodyRequestWrapperV3(httpServletRequest);
     }
 
     @Override
     public HttpServletResponse wrapResponse(HttpServletResponse httpServletResponse) {
+        if (httpServletResponse instanceof CachedBodyResponseWrapperV3) {
+            return httpServletResponse;
+        }
         return new CachedBodyResponseWrapperV3(httpServletResponse);
     }
 
@@ -102,18 +108,37 @@ public class ServletAdapterImplV3 implements ServletAdapter<HttpServletRequest, 
 
     @Override
     public String getFullUrl(HttpServletRequest httpServletRequest) {
-        StringBuilder fullUrl = new StringBuilder(httpServletRequest.getRequestURI());
         String queryString = httpServletRequest.getQueryString();
 
         if (StringUtil.isEmpty(queryString)) {
-            return fullUrl.toString();
+            return httpServletRequest.getRequestURL().toString();
         } else {
-            return fullUrl.append('?').append(queryString).toString();
+            return new StringBuilder(httpServletRequest.getRequestURL()).append('?').append(queryString).toString();
+        }
+    }
+
+    @Override
+    public String getRequestPath(HttpServletRequest httpServletRequest) {
+        String queryString = httpServletRequest.getQueryString();
+
+        if (StringUtil.isEmpty(queryString)) {
+            return httpServletRequest.getRequestURI();
+        } else {
+            return new StringBuilder(httpServletRequest.getRequestURI()).append('?').append(queryString).toString();
         }
     }
 
     @Override
     public String getRequestURI(HttpServletRequest httpServletRequest) {
+        return httpServletRequest.getRequestURI();
+    }
+
+    @Override
+    public String getPattern(HttpServletRequest httpServletRequest) {
+        Object pattern = httpServletRequest.getAttribute("org.springframework.web.servlet.HandlerMapping.bestMatchingPattern");
+        if (pattern != null) {
+            return String.valueOf(pattern);
+        }
         return httpServletRequest.getRequestURI();
     }
 
@@ -168,7 +193,12 @@ public class ServletAdapterImplV3 implements ServletAdapter<HttpServletRequest, 
         if (httpServletRequest.getAttribute(mark) != null) {
             return true;
         }
-        httpServletRequest.setAttribute(mark, Boolean.TRUE.toString());
+        httpServletRequest.setAttribute(mark, Boolean.TRUE);
         return false;
+    }
+
+    @Override
+    public String getParameter(HttpServletRequest servletRequest, String name) {
+        return servletRequest.getParameter(name);
     }
 }

--- a/arex-instrumentation/servlet/arex-httpservlet/src/main/java/io/arex/inst/httpservlet/adapter/impl/ServletAdapterImplV5.java
+++ b/arex-instrumentation/servlet/arex-httpservlet/src/main/java/io/arex/inst/httpservlet/adapter/impl/ServletAdapterImplV5.java
@@ -37,11 +37,17 @@ public class ServletAdapterImplV5 implements ServletAdapter<HttpServletRequest, 
 
     @Override
     public HttpServletRequest wrapRequest(HttpServletRequest httpServletRequest) {
+        if (httpServletRequest instanceof CachedBodyRequestWrapperV5) {
+            return httpServletRequest;
+        }
         return new CachedBodyRequestWrapperV5(httpServletRequest);
     }
 
     @Override
     public HttpServletResponse wrapResponse(HttpServletResponse httpServletResponse) {
+        if (httpServletResponse instanceof CachedBodyResponseWrapperV5) {
+            return httpServletResponse;
+        }
         return new CachedBodyResponseWrapperV5(httpServletResponse);
     }
 
@@ -102,18 +108,37 @@ public class ServletAdapterImplV5 implements ServletAdapter<HttpServletRequest, 
 
     @Override
     public String getFullUrl(HttpServletRequest httpServletRequest) {
-        StringBuilder fullUrl = new StringBuilder(httpServletRequest.getRequestURI());
         String queryString = httpServletRequest.getQueryString();
 
         if (StringUtil.isEmpty(queryString)) {
-            return fullUrl.toString();
+            return httpServletRequest.getRequestURL().toString();
         } else {
-            return fullUrl.append('?').append(queryString).toString();
+            return new StringBuilder(httpServletRequest.getRequestURL()).append('?').append(queryString).toString();
+        }
+    }
+
+    @Override
+    public String getRequestPath(HttpServletRequest httpServletRequest) {
+        String queryString = httpServletRequest.getQueryString();
+
+        if (StringUtil.isEmpty(queryString)) {
+            return httpServletRequest.getRequestURI();
+        } else {
+            return new StringBuilder(httpServletRequest.getRequestURI()).append('?').append(queryString).toString();
         }
     }
 
     @Override
     public String getRequestURI(HttpServletRequest httpServletRequest) {
+        return httpServletRequest.getRequestURI();
+    }
+
+    @Override
+    public String getPattern(HttpServletRequest httpServletRequest) {
+        Object pattern = httpServletRequest.getAttribute("org.springframework.web.servlet.HandlerMapping.bestMatchingPattern");
+        if (pattern != null) {
+            return String.valueOf(pattern);
+        }
         return httpServletRequest.getRequestURI();
     }
 
@@ -168,7 +193,12 @@ public class ServletAdapterImplV5 implements ServletAdapter<HttpServletRequest, 
         if (httpServletRequest.getAttribute(mark) != null) {
             return true;
         }
-        httpServletRequest.setAttribute(mark, Boolean.TRUE.toString());
+        httpServletRequest.setAttribute(mark, Boolean.TRUE);
         return false;
+    }
+
+    @Override
+    public String getParameter(HttpServletRequest httpServletRequest, String name) {
+        return httpServletRequest.getParameter(name);
     }
 }

--- a/arex-instrumentation/servlet/arex-httpservlet/src/main/java/io/arex/inst/httpservlet/wrapper/CachedBodyResponseWrapperV3.java
+++ b/arex-instrumentation/servlet/arex-httpservlet/src/main/java/io/arex/inst/httpservlet/wrapper/CachedBodyResponseWrapperV3.java
@@ -1,6 +1,10 @@
 package io.arex.inst.httpservlet.wrapper;
 
 
+import io.arex.inst.httpservlet.ServletUtil;
+import io.arex.inst.runtime.context.ArexContext;
+import io.arex.inst.runtime.context.ContextManager;
+import io.arex.inst.runtime.model.ArexConstants;
 import javax.servlet.ServletOutputStream;
 import javax.servlet.WriteListener;
 import javax.servlet.http.HttpServletResponse;
@@ -64,6 +68,10 @@ public class CachedBodyResponseWrapperV3 extends HttpServletResponseWrapper {
 
     @Override
     public void sendRedirect(String location) throws IOException {
+        ArexContext context = ContextManager.currentContext();
+        if (context != null) {
+            location = ServletUtil.appendUri(location, ArexConstants.RECORD_ID, context.getCaseId());
+        }
         copyBodyToResponse(false);
         super.sendRedirect(location);
     }

--- a/arex-instrumentation/servlet/arex-httpservlet/src/main/java/io/arex/inst/httpservlet/wrapper/CachedBodyResponseWrapperV5.java
+++ b/arex-instrumentation/servlet/arex-httpservlet/src/main/java/io/arex/inst/httpservlet/wrapper/CachedBodyResponseWrapperV5.java
@@ -1,5 +1,9 @@
 package io.arex.inst.httpservlet.wrapper;
 
+import io.arex.inst.httpservlet.ServletUtil;
+import io.arex.inst.runtime.context.ArexContext;
+import io.arex.inst.runtime.context.ContextManager;
+import io.arex.inst.runtime.model.ArexConstants;
 import jakarta.servlet.ServletOutputStream;
 import jakarta.servlet.WriteListener;
 import jakarta.servlet.http.HttpServletResponse;
@@ -60,6 +64,10 @@ public class CachedBodyResponseWrapperV5 extends HttpServletResponseWrapper {
 
     @Override
     public void sendRedirect(String location) throws IOException {
+        ArexContext context = ContextManager.currentContext();
+        if (context != null) {
+            location = ServletUtil.appendUri(location, ArexConstants.RECORD_ID, context.getCaseId());
+        }
         copyBodyToResponse(false);
         super.sendRedirect(location);
     }

--- a/arex-instrumentation/servlet/arex-httpservlet/src/test/java/io/arex/inst/httpservlet/ServletUtilTest.java
+++ b/arex-instrumentation/servlet/arex-httpservlet/src/test/java/io/arex/inst/httpservlet/ServletUtilTest.java
@@ -1,0 +1,26 @@
+package io.arex.inst.httpservlet;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class ServletUtilTest {
+    @Test
+    void appendUri() {
+        assertEquals("http://arextest.com?name=mark", ServletUtil.appendUri("http://arextest.com", "name", "mark"));
+        assertEquals("http://arextest.com?name=mark#fragment",
+            ServletUtil.appendUri("http://arextest.com#fragment", "name", "mark"));
+
+        assertEquals("http://arextest.com?email=arex.test.com@gmail.com&name=mark",
+            ServletUtil.appendUri("http://arextest.com?email=arex.test.com@gmail.com", "name", "mark"));
+
+        assertEquals("http://arextest.com?email=arex.test.com@gmail.com&name=mark#fragment",
+            ServletUtil.appendUri("http://arextest.com?email=arex.test.com@gmail.com#fragment", "name", "mark"));
+    }
+
+    @Test
+    public void getFullPath() {
+        assertEquals("/servletpath/controll/action", ServletUtil.getRequestPath("http://arextest.com/servletpath/controll/action"));
+        assertEquals("/servletpath/controll/action?k1=v1", ServletUtil.getRequestPath("http://arextest.com/servletpath/controll/action?k1=v1"));
+    }
+}

--- a/arex-instrumentation/servlet/arex-httpservlet/src/test/java/io/arex/inst/httpservlet/adapter/impl/ServletAdapterImplV3Test.java
+++ b/arex-instrumentation/servlet/arex-httpservlet/src/test/java/io/arex/inst/httpservlet/adapter/impl/ServletAdapterImplV3Test.java
@@ -2,6 +2,7 @@ package io.arex.inst.httpservlet.adapter.impl;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import io.arex.inst.httpservlet.wrapper.CachedBodyRequestWrapperV3;
@@ -51,12 +52,12 @@ class ServletAdapterImplV3Test {
 
     @Test
     void wrapRequest() {
-        assertInstanceOf(CachedBodyRequestWrapperV3.class, instance.wrapRequest(mockRequest));
+        assertInstanceOf(CachedBodyRequestWrapperV3.class, instance.wrapRequest(instance.wrapRequest(mockRequest)));
     }
 
     @Test
     void wrapResponse() {
-        assertInstanceOf(CachedBodyResponseWrapperV3.class, instance.wrapResponse(mockResponse));
+        assertInstanceOf(CachedBodyResponseWrapperV3.class, instance.wrapResponse(instance.wrapResponse(mockResponse)));
     }
 
     @Test
@@ -120,17 +121,36 @@ class ServletAdapterImplV3Test {
 
     @Test
     void getFullUrl() {
-        when(mockRequest.getRequestURI()).thenReturn("/commutity/httpClientTest/okHttp");
-        assertEquals("/commutity/httpClientTest/okHttp", instance.getFullUrl(mockRequest));
+        when(mockRequest.getRequestURL()).thenReturn(new StringBuffer("http://arextest.com/servletpath/controll/action"));
+        assertEquals("http://arextest.com/servletpath/controll/action", instance.getFullUrl(mockRequest));
 
         when(mockRequest.getQueryString()).thenReturn("k1=v1&k2=v2");
-        assertEquals("/commutity/httpClientTest/okHttp?k1=v1&k2=v2", instance.getFullUrl(mockRequest));
+        assertEquals("http://arextest.com/servletpath/controll/action?k1=v1&k2=v2", instance.getFullUrl(mockRequest));
+    }
+
+    @Test
+    void getRequestPath() {
+        when(mockRequest.getRequestURI()).thenReturn("/commutity/httpClientTest/okHttp");
+        assertEquals("/commutity/httpClientTest/okHttp", instance.getRequestPath(mockRequest));
+
+        when(mockRequest.getQueryString()).thenReturn("k1=v1&k2=v2");
+        assertEquals("/commutity/httpClientTest/okHttp?k1=v1&k2=v2", instance.getRequestPath(mockRequest));
     }
 
     @Test
     void getRequestURI() {
         when(mockRequest.getRequestURI()).thenReturn("/commutity/httpClientTest/okHttp");
         assertEquals("/commutity/httpClientTest/okHttp", instance.getRequestURI(mockRequest));
+    }
+
+    @Test
+    void getPattern() {
+        when(mockRequest.getAttribute(eq("org.springframework.web.servlet.HandlerMapping.bestMatchingPattern"))).thenReturn("/book/{id}");
+        assertEquals("/book/{id}", instance.getPattern(mockRequest));
+
+        when(mockRequest.getAttribute(eq("org.springframework.web.servlet.HandlerMapping.bestMatchingPattern"))).thenReturn(null);
+        when(mockRequest.getRequestURI()).thenReturn("/commutity/httpClientTest/okHttp");
+        assertEquals("/commutity/httpClientTest/okHttp", instance.getPattern(mockRequest));
     }
 
     @Test
@@ -197,5 +217,11 @@ class ServletAdapterImplV3Test {
         assertTrue(instance.markProcessed(mockRequest, "mock"));
         when(mockRequest.getAttribute(any())).thenReturn(null);
         assertFalse(instance.markProcessed(mockRequest, "mock"));
+    }
+
+    @Test
+    void getParameter() {
+        when(mockRequest.getParameter(any())).thenReturn("mock-parameter");
+        assertEquals("mock-parameter", instance.getParameter(mockRequest, "arex-parameter"));
     }
 }

--- a/arex-instrumentation/servlet/arex-httpservlet/src/test/java/io/arex/inst/httpservlet/adapter/impl/ServletAdapterImplV5Test.java
+++ b/arex-instrumentation/servlet/arex-httpservlet/src/test/java/io/arex/inst/httpservlet/adapter/impl/ServletAdapterImplV5Test.java
@@ -2,6 +2,7 @@ package io.arex.inst.httpservlet.adapter.impl;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import io.arex.inst.httpservlet.wrapper.CachedBodyRequestWrapperV5;
@@ -52,12 +53,12 @@ class ServletAdapterImplV5Test {
 
     @Test
     void wrapRequest() {
-        assertInstanceOf(CachedBodyRequestWrapperV5.class, instance.wrapRequest(mockRequest));
+        assertInstanceOf(CachedBodyRequestWrapperV5.class, instance.wrapRequest(instance.wrapRequest(mockRequest)));
     }
 
     @Test
     void wrapResponse() {
-        assertInstanceOf(CachedBodyResponseWrapperV5.class, instance.wrapResponse(mockResponse));
+        assertInstanceOf(CachedBodyResponseWrapperV5.class, instance.wrapResponse(instance.wrapResponse(mockResponse)));
     }
 
     @Test
@@ -121,17 +122,36 @@ class ServletAdapterImplV5Test {
 
     @Test
     void getFullUrl() {
-        when(mockRequest.getRequestURI()).thenReturn("/commutity/httpClientTest/okHttp");
-        assertEquals("/commutity/httpClientTest/okHttp", instance.getFullUrl(mockRequest));
+        when(mockRequest.getRequestURL()).thenReturn(new StringBuffer("http://arextest.com/servletpath/controll/action"));
+        assertEquals("http://arextest.com/servletpath/controll/action", instance.getFullUrl(mockRequest));
 
         when(mockRequest.getQueryString()).thenReturn("k1=v1&k2=v2");
-        assertEquals("/commutity/httpClientTest/okHttp?k1=v1&k2=v2", instance.getFullUrl(mockRequest));
+        assertEquals("http://arextest.com/servletpath/controll/action?k1=v1&k2=v2", instance.getFullUrl(mockRequest));
+    }
+
+    @Test
+    void getRequestPath() {
+        when(mockRequest.getRequestURI()).thenReturn("/commutity/httpClientTest/okHttp");
+        assertEquals("/commutity/httpClientTest/okHttp", instance.getRequestPath(mockRequest));
+
+        when(mockRequest.getQueryString()).thenReturn("k1=v1&k2=v2");
+        assertEquals("/commutity/httpClientTest/okHttp?k1=v1&k2=v2", instance.getRequestPath(mockRequest));
     }
 
     @Test
     void getRequestURI() {
         when(mockRequest.getRequestURI()).thenReturn("/commutity/httpClientTest/okHttp");
         assertEquals("/commutity/httpClientTest/okHttp", instance.getRequestURI(mockRequest));
+    }
+
+    @Test
+    void getPattern() {
+        when(mockRequest.getAttribute(eq("org.springframework.web.servlet.HandlerMapping.bestMatchingPattern"))).thenReturn("/book/{id}");
+        assertEquals("/book/{id}", instance.getPattern(mockRequest));
+
+        when(mockRequest.getAttribute(eq("org.springframework.web.servlet.HandlerMapping.bestMatchingPattern"))).thenReturn(null);
+        when(mockRequest.getRequestURI()).thenReturn("/commutity/httpClientTest/okHttp");
+        assertEquals("/commutity/httpClientTest/okHttp", instance.getPattern(mockRequest));
     }
 
     @Test
@@ -198,5 +218,11 @@ class ServletAdapterImplV5Test {
         assertTrue(instance.markProcessed(mockRequest, "mock"));
         when(mockRequest.getAttribute(any())).thenReturn(null);
         assertFalse(instance.markProcessed(mockRequest, "mock"));
+    }
+
+    @Test
+    void getParameter() {
+        when(mockRequest.getParameter(any())).thenReturn("mock-parameter");
+        assertEquals("mock-parameter", instance.getParameter(mockRequest, "arex-parameter"));
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,9 @@
             **/*Test.java,
             **/target/**,
             **/model/**,
-            **/serializer/**
+            **/serializer/**,
+            **/context/**,
+            **/wrapper/**
         </sonar.coverage.exclusions>
     </properties>
 


### PR DESCRIPTION
Fix: #51 

1. Store the original url to context when response returns 302
2. Change `sendRedirect` method to pass `arex-record-id` of the original request
3. Save recorded data base on request type: redirect or not