### PR TITLE
fix: ForkJoinTask inner class not transform

### DIFF
--- a/arex-agent-core/src/main/java/io/arex/agent/instrumentation/BaseAgentInstaller.java
+++ b/arex-agent-core/src/main/java/io/arex/agent/instrumentation/BaseAgentInstaller.java
@@ -18,6 +18,7 @@ import io.arex.inst.runtime.service.DataCollector;
 import io.arex.inst.runtime.service.DataService;
 import io.arex.inst.runtime.util.LogUtil;
 import java.util.List;
+import java.util.concurrent.ForkJoinTask;
 import net.bytebuddy.agent.builder.ResettableClassFileTransformer;
 
 import java.io.File;
@@ -56,6 +57,15 @@ public abstract class BaseAgentInstaller implements AgentInstaller {
         RecordLimiter.init(HealthManager::acquire);
         ConfigService.INSTANCE.loadAgentConfig(agentArgs);
         initDataCollector();
+        loadForkJoinTask();
+    }
+
+    /**
+     * Load the ForkJoinTask inner class in advance for transform
+     * ex: java.util.concurrent.ForkJoinTask$AdaptedCallable
+     */
+    private void loadForkJoinTask() {
+        ForkJoinTask.class.getDeclaredClasses();
     }
 
     private void installSerializer() {


### PR DESCRIPTION
bytebuddy transform logic:
1. When `builder.installOn(instrumentation)`, get all the classes loaded in the current loader, match according to the defined transformer, and match the classes to form a mapping relationship: `className -> Instrumentation`.

2. When the class that is not loaded `after builder.installOn(instrumentation)` is completed is loaded, it will be matched by calling the classLoader transformer through classLoader defineClass, and the matched class will be modified.

However, when the agent `builder.installOn(instrumentation)` obtained the config configuration through `io.arex.foundation.util.AsyncHttpClientUtil` before, 
the use of `new CompletableFuture<>()` caused the ForkJoinTask class to be loaded, but the innerClass did not (ex: `java.util.concurrent.ForkJoinTask$AdaptedCallable`).

1. When `builder.installOn(instrumentation)`, due to the `hasSuperType(named("java.util.concurrent.ForkJoinTask")) in ForkJoinTaskInstrumentation`, when transforming `ForkJoinTask.class`, there is a getDeclareClass operation, which causes the subclass to be loaded, and because there is no such match in the mapping relationship: `className -> Instrumentation` in the first matching rule, the first one is not matched.

2. `After builder.installOn(instrumentation)`, since the class has already been loaded, which causes fail to match the second rule, and eventually these internal classes are not transformed.