### PR TITLE
chore: change to sonar.token

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@
 
 name: Build and Test
 
-on: [push, pull_request, workflow_dispatch]
+on: [pull_request, workflow_dispatch]
 
 jobs:
   build-source:
@@ -53,7 +53,7 @@ jobs:
     - name: Maven Test with SonarCloud Scan
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-      run: mvn --batch-mode --no-transfer-progress --fail-fast clean test verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=arextest_arex-agent-java -Dsonar.host.url=https://sonarcloud.io -Dsonar.organization=arextest -Dsonar.login=1f4a261beca6bbf7c93c3cf80bbc198de74d1020 -DskipTests=false
+      run: mvn --batch-mode --no-transfer-progress --fail-fast clean test verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=arextest_arex-agent-java -Dsonar.host.url=https://sonarcloud.io -Dsonar.organization=arextest -Dsonar.token=1f4a261beca6bbf7c93c3cf80bbc198de74d1020 -DskipTests=false
     - name: Codecov
       uses: codecov/codecov-action@v3.1.0
     


### PR DESCRIPTION
The property 'sonar.login' is deprecated and will be removed in the future. Please use the 'sonar.token' property instead when passing a token.