### PR TITLE
fix: check apollo loaded

### DIFF
--- a/arex-instrumentation/config/arex-apollo/src/main/java/io/arex/inst/config/apollo/ApolloConfigHelper.java
+++ b/arex-instrumentation/config/arex-apollo/src/main/java/io/arex/inst/config/apollo/ApolloConfigHelper.java
@@ -50,6 +50,16 @@ import java.util.function.Supplier;
  */
 public class ApolloConfigHelper {
     private static Field configInstancesField;
+    private static boolean isLoadedApollo = false;
+
+    static {
+        try {
+            Class.forName("com.ctrip.framework.apollo.ConfigService");
+            isLoadedApollo = true;
+        } catch (ClassNotFoundException e) {
+            // ignore, means business application unLoad apollo-client
+        }
+    }
 
     public static void initAndRecord(Supplier<String> recordIdSpl, Supplier<String> versionSpl) {
         String recordId = recordIdSpl.get();
@@ -212,5 +222,9 @@ public class ApolloConfigHelper {
      */
     private static String getReleaseKey() {
         return ArexConstants.PREFIX + ApolloConfigExtractor.currentReplayConfigBatchNo();
+    }
+
+    public static boolean unloadApollo() {
+        return !isLoadedApollo;
     }
 }

--- a/arex-instrumentation/config/arex-apollo/src/main/java/io/arex/inst/config/apollo/ApolloDubboRequestHandler.java
+++ b/arex-instrumentation/config/arex-apollo/src/main/java/io/arex/inst/config/apollo/ApolloDubboRequestHandler.java
@@ -17,6 +17,10 @@ public class ApolloDubboRequestHandler implements RequestHandler<Map<String, Str
 
     @Override
     public void preHandle(Map<String, String> request) {
+        // check business application if loaded apollo-client
+        if (ApolloConfigHelper.unloadApollo()) {
+            return;
+        }
         ApolloConfigHelper.initAndRecord(
                 () -> request.get(ArexConstants.RECORD_ID),
                 () -> request.get(ArexConstants.CONFIG_DEPENDENCY));
@@ -40,6 +44,6 @@ public class ApolloDubboRequestHandler implements RequestHandler<Map<String, Str
         if (request == null) {
             return true;
         }
-        return !ContextManager.needRecord();
+        return !ContextManager.needRecord() || ApolloConfigHelper.unloadApollo();
     }
 }

--- a/arex-instrumentation/config/arex-apollo/src/main/java/io/arex/inst/config/apollo/ApolloServletV3RequestHandler.java
+++ b/arex-instrumentation/config/arex-apollo/src/main/java/io/arex/inst/config/apollo/ApolloServletV3RequestHandler.java
@@ -17,6 +17,10 @@ public class ApolloServletV3RequestHandler implements RequestHandler<HttpServlet
 
     @Override
     public void preHandle(HttpServletRequest request) {
+        // check business application if loaded apollo-client
+        if (ApolloConfigHelper.unloadApollo()) {
+            return;
+        }
         ApolloConfigHelper.initAndRecord(
                 () -> request.getHeader(ArexConstants.RECORD_ID),
                 () -> request.getHeader(ArexConstants.CONFIG_DEPENDENCY));
@@ -43,6 +47,6 @@ public class ApolloServletV3RequestHandler implements RequestHandler<HttpServlet
         if (response.getHeader(ArexConstants.RECORD_ID) != null) {
             return true;
         }
-        return !ContextManager.needRecord();
+        return !ContextManager.needRecord() || ApolloConfigHelper.unloadApollo();
     }
 }

--- a/arex-instrumentation/config/arex-apollo/src/test/java/io/arex/inst/config/apollo/ApolloConfigHelperTest.java
+++ b/arex-instrumentation/config/arex-apollo/src/test/java/io/arex/inst/config/apollo/ApolloConfigHelperTest.java
@@ -23,8 +23,7 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
@@ -176,5 +175,10 @@ class ApolloConfigHelperTest {
                 arguments(mocker1, previous3, predicate_isNull),
                 arguments(mocker2, previous3, predicate_nonNull)
         );
+    }
+
+    @Test
+    void unloadApollo() {
+        assertFalse(ApolloConfigHelper.unloadApollo());
     }
 }


### PR DESCRIPTION
If business application not loaded apollo-client.jar, it will log "ClassNoDefFound" exception(doesn't affect normal business logic),
and we will refactor this issue on next version.