### PR TITLE
feat: supports parse positionalParameter in hibernate

### DIFF
--- a/arex-instrumentation/database/arex-database-common/src/main/java/io/arex/inst/database/common/DatabaseHelper.java
+++ b/arex-instrumentation/database/arex-database-common/src/main/java/io/arex/inst/database/common/DatabaseHelper.java
@@ -1,5 +1,6 @@
 package io.arex.inst.database.common;
 
+import io.arex.agent.bootstrap.util.ArrayUtils;
 import io.arex.agent.bootstrap.util.MapUtils;
 import io.arex.inst.runtime.model.ArexConstants;
 import io.arex.inst.runtime.serializer.Serializer;
@@ -8,7 +9,6 @@ import org.hibernate.engine.spi.TypedValue;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.stream.IntStream;
 
 public class DatabaseHelper {
@@ -25,7 +25,7 @@ public class DatabaseHelper {
             for (Map.Entry<String, TypedValue> entry : parameters.entrySet()) {
                 parameterMap.put(entry.getKey(), entry.getValue().getValue());
             }
-        } else if (Objects.nonNull(positionalParameterValues) && positionalParameterValues.length > 0) {
+        } else if (ArrayUtils.isNotEmpty(positionalParameterValues)) {
             IntStream.range(0, positionalParameterValues.length)
                     .forEach(i -> parameterMap.put(String.valueOf(i), positionalParameterValues[i]));
         } else {

--- a/arex-instrumentation/database/arex-database-common/src/test/java/io/arex/inst/database/common/DatabaseHelperTest.java
+++ b/arex-instrumentation/database/arex-database-common/src/test/java/io/arex/inst/database/common/DatabaseHelperTest.java
@@ -47,10 +47,14 @@ class DatabaseHelperTest {
     static Stream<Arguments> parseParameterCase() {
         QueryParameters queryParameters1 = Mockito.mock(QueryParameters.class);
         QueryParameters queryParameters2 = Mockito.mock(QueryParameters.class);
+        QueryParameters queryParameters3 = Mockito.mock(QueryParameters.class);
 
         Map<String, TypedValue> parameters = new HashMap<>();
         parameters.put("key", Mockito.mock(TypedValue.class));
         Mockito.when(queryParameters2.getNamedParameters()).thenReturn(parameters);
+
+        Object[] positionalParameters = new Object[]{"mock1", 2, "mock3"};
+        Mockito.when(queryParameters3.getPositionalParameterValues()).thenReturn(positionalParameters);
 
         Mockito.when(Serializer.serialize(any(), eq(ArexConstants.JACKSON_REQUEST_SERIALIZER))).thenReturn("mock Serializer.serialize");
 
@@ -60,7 +64,8 @@ class DatabaseHelperTest {
         return Stream.of(
                 arguments(null, predicate1),
                 arguments(queryParameters1, predicate1),
-                arguments(queryParameters2, predicate2)
+                arguments(queryParameters2, predicate2),
+                arguments(queryParameters3, predicate2)
         );
     }
 }


### PR DESCRIPTION
#### 支持解析 hibernate 位置参数。

原逻辑只处理了 hql 的命名参数，没有处理位置参数，若查询语句为：
```java
Query query=session.createQuery(“from User user where user.id=?”); 
query.setInteger(0, 410); 
```
则会记录不到参数，直接返回 null：
<img width="1409" alt="image" src="https://github.com/arextest/arex-agent-java/assets/30255624/756108ab-1df6-4778-98b0-ecb4a810ed0e">

修改后效果：
<img width="853" alt="image" src="https://github.com/arextest/arex-agent-java/assets/30255624/387c92b7-878d-48d9-bd1b-a7a8a089214d">
