### PR TITLE
解决【dubbo3.0子调用mock结果为null，取不到录制数据】的问题 https://github.com/arextest/are…

### DIFF
--- a/arex-instrumentation/dubbo/arex-dubbo-alibaba/src/main/java/io/arex/inst/dubbo/alibaba/DubboAdapter.java
+++ b/arex-instrumentation/dubbo/arex-dubbo-alibaba/src/main/java/io/arex/inst/dubbo/alibaba/DubboAdapter.java
@@ -1,22 +1,22 @@
 package io.arex.inst.dubbo.alibaba;
 
+import com.alibaba.dubbo.common.URL;
 import com.alibaba.dubbo.remoting.exchange.ResponseCallback;
 import com.alibaba.dubbo.remoting.exchange.ResponseFuture;
 import com.alibaba.dubbo.rpc.*;
 import com.alibaba.dubbo.rpc.protocol.dubbo.FutureAdapter;
+import com.alibaba.dubbo.rpc.support.ProtocolUtils;
 import com.alibaba.dubbo.rpc.support.RpcUtils;
 import io.arex.agent.bootstrap.ctx.TraceTransmitter;
 import io.arex.agent.bootstrap.model.Mocker;
 import io.arex.agent.bootstrap.util.ReflectUtil;
 import io.arex.inst.dubbo.common.AbstractAdapter;
 import io.arex.inst.runtime.log.LogManager;
-import com.alibaba.dubbo.common.URL;
-import com.alibaba.dubbo.rpc.support.ProtocolUtils;
-import java.util.Collections;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Method;
+import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.Future;
 
@@ -38,7 +38,11 @@ public class DubboAdapter extends AbstractAdapter {
 
     @Override
     public String getServiceName() {
-        return getUrl().getServiceInterface();
+        /*
+          format：group/interface:version
+          method：org.apache.dubbo.common.BaseServiceMetadata#buildServiceKey() | org.apache.dubbo.common.URL#buildKey()
+         */
+        return getUrl().getServiceKey();
     }
 
     /**

--- a/arex-instrumentation/dubbo/arex-dubbo-apache-v2/src/main/java/io/arex/inst/dubbo/apache/v2/DubboAdapter.java
+++ b/arex-instrumentation/dubbo/arex-dubbo-apache-v2/src/main/java/io/arex/inst/dubbo/apache/v2/DubboAdapter.java
@@ -30,7 +30,11 @@ public class DubboAdapter extends AbstractAdapter {
 
     @Override
     public String getServiceName() {
-        return getUrl().getServiceInterface();
+        /*
+          format：group/interface:version
+          method：org.apache.dubbo.common.BaseServiceMetadata#buildServiceKey() | org.apache.dubbo.common.URL#buildKey()
+         */
+        return getUrl().getServiceKey();
     }
 
     /**

--- a/arex-instrumentation/dubbo/arex-dubbo-apache-v3/src/main/java/io/arex/inst/dubbo/apache/v3/DubboAdapter.java
+++ b/arex-instrumentation/dubbo/arex-dubbo-apache-v3/src/main/java/io/arex/inst/dubbo/apache/v3/DubboAdapter.java
@@ -34,6 +34,7 @@ public class DubboAdapter extends AbstractAdapter {
 
     @Override
     public String getServiceName() {
+        // format：group/interface:version
         return invocation.getTargetServiceUniqueName();
     }
 

--- a/arex-instrumentation/dubbo/arex-dubbo-common/src/main/java/io/arex/inst/dubbo/common/AbstractAdapter.java
+++ b/arex-instrumentation/dubbo/arex-dubbo-common/src/main/java/io/arex/inst/dubbo/common/AbstractAdapter.java
@@ -118,7 +118,31 @@ public abstract class AbstractAdapter {
     }
 
     public String getPath() {
-        return StringUtil.defaultIfEmpty(getAttachment("path"), getServiceName());
+        return StringUtil.defaultIfEmpty(this.getServiceNameWithVersion(), this.getServiceName());
+    }
+
+    /**
+     * <p>Illustrate: Splicing serviceName and version
+     * <p>Fix Bug: https://github.com/arextest/arex-agent-java/issues/490
+     * <p>Notice: This method maybe affect ignore [path] config！ Especially when a dubbo service exists multiple versions！
+     */
+    protected String getServiceNameWithVersion(){
+        String serviceName = this.getAttachment("path");
+        if (StringUtil.isBlank(serviceName)){
+            return null;
+        }
+        String group = this.getValByKey("group");
+        String version = this.getAttachment("version");
+        // splicing：group/interface:version
+        StringBuilder serviceKey = new StringBuilder();
+        if (!StringUtil.isBlank(group)) {
+            serviceKey.append(group).append("/");
+        }
+        serviceKey.append(serviceName);
+        if (!StringUtil.isBlank(version)) {
+            serviceKey.append(":").append(version);
+        }
+        return serviceKey.toString();
     }
 
     /**


### PR DESCRIPTION
fix #490 

可能带来的影响面：
●对dubbo2.0、dubbo3.0的兼容性；
●同时补全对group和version的支持；优化后的完整服务名格式：group/interface:version
●对【忽略mock配置】带来的影响，新的ignore mock path格式可能会导致旧的配置失效；
另外：
[如果接受PR，请更新该章节中dubbo服务名的配置说明，最好给出案例](https://docs.arextest.com/zh-Hans/docs/chapter3/record-replay-config/#%E5%9B%9E%E6%94%BE%E8%AE%BE%E7%BD%AE)
