### PR TITLE
fix: buildSkipInfos error when fieldName is empty

### DIFF
--- a/arex-instrumentation-api/src/main/java/io/arex/inst/runtime/config/listener/SerializeSkipInfoListener.java
+++ b/arex-instrumentation-api/src/main/java/io/arex/inst/runtime/config/listener/SerializeSkipInfoListener.java
@@ -69,7 +69,7 @@ public class SerializeSkipInfoListener implements ConfigListener {
                 // Split the string into key and value
                 String[] keyValue = pair.split(":");
                 // Set the value in the SerializerSkipInfo object
-                if (keyValue[0].contains("fullClassName")) {
+                if (keyValue[0].contains("fullClassName") && keyValue.length > 1) {
                     className = keyValue[1];
                 } else if (keyValue[0].contains("fieldName") && keyValue.length > 1) {
                     fieldNameTemp = keyValue[1];

--- a/arex-instrumentation-api/src/main/java/io/arex/inst/runtime/config/listener/SerializeSkipInfoListener.java
+++ b/arex-instrumentation-api/src/main/java/io/arex/inst/runtime/config/listener/SerializeSkipInfoListener.java
@@ -71,7 +71,7 @@ public class SerializeSkipInfoListener implements ConfigListener {
                 // Set the value in the SerializerSkipInfo object
                 if (keyValue[0].contains("fullClassName")) {
                     className = keyValue[1];
-                } else if (keyValue[0].contains("fieldName")) {
+                } else if (keyValue[0].contains("fieldName") && keyValue.length > 1) {
                     fieldNameTemp = keyValue[1];
                 }
             }

--- a/arex-instrumentation-foundation/src/main/java/io/arex/foundation/services/ConfigService.java
+++ b/arex-instrumentation-foundation/src/main/java/io/arex/foundation/services/ConfigService.java
@@ -86,7 +86,7 @@ public class ConfigService {
             }
             ConfigManager.INSTANCE.updateConfigFromService(configResponse.getBody());
         } catch (Throwable e) {
-            LOGGER.warn("[AREX] Load agent config error, pause recording. exception message: {}", e.getMessage());
+            LOGGER.warn("[AREX] Load agent config error, pause recording. exception message: {}", e.getMessage(), e);
             ConfigManager.INSTANCE.setConfigInvalid();
         }
     }


### PR DESCRIPTION
### 问题描述
序列化忽略配置，没有指定字段名时，解析配置时数组越界异常：
<img width="1217" alt="image" src="https://github.com/arextest/arex-agent-java/assets/30255624/c8e3cf20-0064-4cd3-8dfc-d9c246926a6d">

<img width="1189" alt="image" src="https://github.com/arextest/arex-agent-java/assets/30255624/4575f9c3-aff6-4b21-8463-23ee53f2aac2">

查看代码发现没有做判断：
![image](https://github.com/arextest/arex-agent-java/assets/30255624/d8bbc206-460d-4d5f-b530-a061905e7431)

### 解决方式
添加数组长度判断即可。
![image](https://github.com/arextest/arex-agent-java/assets/30255624/836ead99-aec5-4edd-a5f4-0622905caeff)

