### PR TITLE
feat: add parse record rule config

### DIFF
--- a/arex-instrumentation-api/src/main/java/io/arex/inst/runtime/config/Config.java
+++ b/arex-instrumentation-api/src/main/java/io/arex/inst/runtime/config/Config.java
@@ -6,6 +6,7 @@ import io.arex.agent.bootstrap.util.StringUtil;
 import io.arex.inst.runtime.context.RecordLimiter;
 import io.arex.inst.runtime.listener.EventProcessor;
 import io.arex.inst.runtime.model.DynamicClassEntity;
+import io.arex.inst.runtime.model.RecordRuleEntity;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -24,10 +25,11 @@ public class Config {
 
     static void update(boolean enableDebug, String serviceName, List<DynamicClassEntity> dynamicClassList,
         Map<String, String> properties, Set<String> excludeServiceOperations,
-        int dubboStreamReplayThreshold, int recordRate) {
+        int dubboStreamReplayThreshold, int recordRate,
+        List<RecordRuleEntity> recordRuleList, boolean existUrlParamRule, boolean existBodyParamRule) {
         INSTANCE = new Config(enableDebug, serviceName, dynamicClassList, properties,
-            excludeServiceOperations,
-            dubboStreamReplayThreshold, recordRate);
+            excludeServiceOperations, dubboStreamReplayThreshold, recordRate,
+            recordRuleList, existUrlParamRule, existBodyParamRule);
     }
 
     public static Config get() {
@@ -46,10 +48,14 @@ public class Config {
     private final String recordVersion;
     private final Set<String> includeServiceOperations;
     private final String[] coveragePackages;
+    private final List<RecordRuleEntity> recordRuleList;
+    private final boolean existUrlParamRule;
+    private final boolean existBodyParamRule;
 
     Config(boolean enableDebug, String serviceName, List<DynamicClassEntity> dynamicClassList,
         Map<String, String> properties,
-        Set<String> excludeServiceOperations, int dubboStreamReplayThreshold, int recordRate) {
+        Set<String> excludeServiceOperations, int dubboStreamReplayThreshold, int recordRate,
+        List<RecordRuleEntity> recordRuleList, boolean existUrlParamRule, boolean existBodyParamRule) {
         this.enableDebug = enableDebug;
         this.serviceName = serviceName;
         this.dynamicClassList = dynamicClassList;
@@ -60,6 +66,9 @@ public class Config {
         this.recordVersion = properties.get("arex.agent.version");
         this.includeServiceOperations = StringUtil.splitToSet(properties.get("includeServiceOperations"), ',');
         this.coveragePackages = StringUtil.split(properties.get(ConfigConstants.COVERAGE_PACKAGES), ',');
+        this.recordRuleList = recordRuleList;
+        this.existUrlParamRule = existUrlParamRule;
+        this.existBodyParamRule = existBodyParamRule;
         buildDynamicClassInfo();
     }
 
@@ -185,6 +194,18 @@ public class Config {
 
     public boolean isLocalStorage() {
         return STORAGE_MODE.equalsIgnoreCase(getString(STORAGE_SERVICE_MODE));
+    }
+
+    public List<RecordRuleEntity> getRecordRuleList() {
+        return recordRuleList;
+    }
+
+    public boolean isExistUrlParamRule() {
+        return existUrlParamRule;
+    }
+
+    public boolean isExistBodyParamRule() {
+        return existBodyParamRule;
     }
 
     /**

--- a/arex-instrumentation-api/src/main/java/io/arex/inst/runtime/config/ConfigBuilder.java
+++ b/arex-instrumentation-api/src/main/java/io/arex/inst/runtime/config/ConfigBuilder.java
@@ -1,6 +1,7 @@
 package io.arex.inst.runtime.config;
 
 import io.arex.inst.runtime.model.DynamicClassEntity;
+import io.arex.inst.runtime.model.RecordRuleEntity;
 
 import java.util.*;
 
@@ -12,6 +13,9 @@ public class ConfigBuilder {
     private Set<String> excludeServiceOperations;
     private int dubboStreamReplayThreshold;
     private int recordRate;
+    private List<RecordRuleEntity> recordRuleList;
+    private boolean existUrlParamRule;
+    private boolean existBodyParamRule;
 
     public static ConfigBuilder create(String serviceName) {
         return new ConfigBuilder(serviceName);
@@ -69,8 +73,23 @@ public class ConfigBuilder {
         return this;
     }
 
+    public ConfigBuilder recordRuleList(List<RecordRuleEntity> recordRuleList) {
+        this.recordRuleList = recordRuleList;
+        return this;
+    }
+
+    public ConfigBuilder existUrlParamRule(boolean existUrlParamRule) {
+        this.existUrlParamRule = existUrlParamRule;
+        return this;
+    }
+
+    public ConfigBuilder existBodyParamRule(boolean existBodyParamRule) {
+        this.existBodyParamRule = existBodyParamRule;
+        return this;
+    }
+
     public void build() {
         Config.update(enableDebug, serviceName, dynamicClassList, Collections.unmodifiableMap(new HashMap<>(properties)),
-            excludeServiceOperations, dubboStreamReplayThreshold, recordRate);
+                excludeServiceOperations, dubboStreamReplayThreshold, recordRate, recordRuleList, existUrlParamRule, existBodyParamRule);
     }
 }

--- a/arex-instrumentation-api/src/main/java/io/arex/inst/runtime/model/ParamRuleEntity.java
+++ b/arex-instrumentation-api/src/main/java/io/arex/inst/runtime/model/ParamRuleEntity.java
@@ -1,0 +1,54 @@
+package io.arex.inst.runtime.model;
+
+import java.util.List;
+
+public class ParamRuleEntity {
+    private String appId;
+    private String urlRuleId;
+    private String paramRuleId;
+    /**
+     * 参数类型枚举：url末尾参数:QUERY_STRING, body参数JSON格式:JSON_BODY
+     */
+    private String paramType;
+    private List<ValueRuleEntity> valueRuleEntityList;
+
+    public String getAppId() {
+        return appId;
+    }
+
+    public void setAppId(String appId) {
+        this.appId = appId;
+    }
+
+    public String getUrlRuleId() {
+        return urlRuleId;
+    }
+
+    public void setUrlRuleId(String urlRuleId) {
+        this.urlRuleId = urlRuleId;
+    }
+
+    public String getParamRuleId() {
+        return paramRuleId;
+    }
+
+    public void setParamRuleId(String paramRuleId) {
+        this.paramRuleId = paramRuleId;
+    }
+
+    public String getParamType() {
+        return paramType;
+    }
+
+    public void setParamType(String paramType) {
+        this.paramType = paramType;
+    }
+
+    public List<ValueRuleEntity> getValueRuleEntityList() {
+        return valueRuleEntityList;
+    }
+
+    public void setValueRuleEntityList(List<ValueRuleEntity> valueRuleEntityList) {
+        this.valueRuleEntityList = valueRuleEntityList;
+    }
+}

--- a/arex-instrumentation-api/src/main/java/io/arex/inst/runtime/model/ParamRuleEntity.java
+++ b/arex-instrumentation-api/src/main/java/io/arex/inst/runtime/model/ParamRuleEntity.java
@@ -3,14 +3,19 @@ package io.arex.inst.runtime.model;
 import java.util.List;
 
 public class ParamRuleEntity {
+    private String id;
     private String appId;
     private String urlRuleId;
-    private String paramRuleId;
-    /**
-     * 参数类型枚举：url末尾参数:QUERY_STRING, body参数JSON格式:JSON_BODY
-     */
     private String paramType;
     private List<ValueRuleEntity> valueRuleEntityList;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
 
     public String getAppId() {
         return appId;
@@ -26,14 +31,6 @@ public class ParamRuleEntity {
 
     public void setUrlRuleId(String urlRuleId) {
         this.urlRuleId = urlRuleId;
-    }
-
-    public String getParamRuleId() {
-        return paramRuleId;
-    }
-
-    public void setParamRuleId(String paramRuleId) {
-        this.paramRuleId = paramRuleId;
     }
 
     public String getParamType() {

--- a/arex-instrumentation-api/src/main/java/io/arex/inst/runtime/model/RecordRuleEntity.java
+++ b/arex-instrumentation-api/src/main/java/io/arex/inst/runtime/model/RecordRuleEntity.java
@@ -1,0 +1,42 @@
+package io.arex.inst.runtime.model;
+
+import java.util.List;
+
+public class RecordRuleEntity {
+    private String appId;
+    private String urlRuleId;
+    private String httpPath;
+    private List<ParamRuleEntity> paramRuleEntityList;
+
+    public String getAppId() {
+        return appId;
+    }
+
+    public void setAppId(String appId) {
+        this.appId = appId;
+    }
+
+    public String getUrlRuleId() {
+        return urlRuleId;
+    }
+
+    public void setUrlRuleId(String urlRuleId) {
+        this.urlRuleId = urlRuleId;
+    }
+
+    public String getHttpPath() {
+        return httpPath;
+    }
+
+    public void setHttpPath(String httpPath) {
+        this.httpPath = httpPath;
+    }
+
+    public List<ParamRuleEntity> getParamRuleEntityList() {
+        return paramRuleEntityList;
+    }
+
+    public void setParamRuleEntityList(List<ParamRuleEntity> paramRuleEntityList) {
+        this.paramRuleEntityList = paramRuleEntityList;
+    }
+}

--- a/arex-instrumentation-api/src/main/java/io/arex/inst/runtime/model/RecordRuleEntity.java
+++ b/arex-instrumentation-api/src/main/java/io/arex/inst/runtime/model/RecordRuleEntity.java
@@ -3,10 +3,18 @@ package io.arex.inst.runtime.model;
 import java.util.List;
 
 public class RecordRuleEntity {
+    private String id;
     private String appId;
-    private String urlRuleId;
     private String httpPath;
     private List<ParamRuleEntity> paramRuleEntityList;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
 
     public String getAppId() {
         return appId;
@@ -14,14 +22,6 @@ public class RecordRuleEntity {
 
     public void setAppId(String appId) {
         this.appId = appId;
-    }
-
-    public String getUrlRuleId() {
-        return urlRuleId;
-    }
-
-    public void setUrlRuleId(String urlRuleId) {
-        this.urlRuleId = urlRuleId;
     }
 
     public String getHttpPath() {

--- a/arex-instrumentation-api/src/main/java/io/arex/inst/runtime/model/ValueRuleEntity.java
+++ b/arex-instrumentation-api/src/main/java/io/arex/inst/runtime/model/ValueRuleEntity.java
@@ -1,0 +1,22 @@
+package io.arex.inst.runtime.model;
+
+public class ValueRuleEntity {
+    private String key;
+    private String value;
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}

--- a/arex-instrumentation-api/src/main/java/io/arex/inst/runtime/util/IgnoreUtils.java
+++ b/arex-instrumentation-api/src/main/java/io/arex/inst/runtime/util/IgnoreUtils.java
@@ -18,6 +18,9 @@ public class IgnoreUtils {
      */
     private static final Set<Integer> INVALID_OPERATION_HASH_CACHE = new ConcurrentHashSet<>();
 
+    public static final String PARAM_TYPE_QUERY_STRING = "QUERY_STRING";
+    public static final String PARAM_TYPE_JSON_BODY = "JSON_BODY";
+
     public static boolean ignoreMockResult(String serviceKey, String operationKey) {
         if (StringUtil.isEmpty(serviceKey)) {
             return false;

--- a/arex-instrumentation-foundation/src/main/java/io/arex/foundation/model/ConfigQueryResponse.java
+++ b/arex-instrumentation-foundation/src/main/java/io/arex/foundation/model/ConfigQueryResponse.java
@@ -63,6 +63,7 @@ public class ConfigQueryResponse {
         private List<DynamicClassConfiguration> dynamicClassConfigurationList;
         private boolean agentEnabled;
         private Map<String, String> extendField;
+        private List<RecordUrlConfiguration> recordUrlConfigurationList;
 
         public ServiceCollectConfig getServiceCollectConfiguration() {
             return serviceCollectConfiguration;
@@ -113,6 +114,15 @@ public class ConfigQueryResponse {
         public void setExtendField(Map<String, String> extendField) {
             this.extendField = extendField;
         }
+
+        public List<RecordUrlConfiguration> getRecordUrlConfigurationList() {
+            return recordUrlConfigurationList;
+        }
+
+        public void setRecordUrlConfigurationList(List<RecordUrlConfiguration> recordUrlConfigurationList) {
+            this.recordUrlConfigurationList = recordUrlConfigurationList;
+        }
+
     }
 
     public static class ServiceCollectConfig {
@@ -219,6 +229,119 @@ public class ConfigQueryResponse {
 
         public void setKeyFormula(String keyFormula) {
             this.keyFormula = keyFormula;
+        }
+    }
+
+    public static class RecordUrlConfiguration {
+        private String id;
+        private String appId;
+        private String httpPath;
+        private List<ParamRule> paramRuleList;
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public String getAppId() {
+            return appId;
+        }
+
+        public void setAppId(String appId) {
+            this.appId = appId;
+        }
+
+        public String getHttpPath() {
+            return httpPath;
+        }
+
+        public void setHttpPath(String httpPath) {
+            this.httpPath = httpPath;
+        }
+
+        public List<ParamRule> getParamRuleList() {
+            return paramRuleList;
+        }
+
+        public void setParamRuleList(List<ParamRule> paramRuleList) {
+            this.paramRuleList = paramRuleList;
+        }
+    }
+
+    public static class ParamRule {
+        private String id;
+        private String appId;
+        private String urlRuleId;
+        /**
+         * Parameter type enumeration:
+         *  QUERY_STRING: http request URL parameters
+         *  JSON_BODY: http request body parameters in JSON format
+         */
+        private String paramType;
+        private List<ValueRule> valueRuleList;
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public String getAppId() {
+            return appId;
+        }
+
+        public void setAppId(String appId) {
+            this.appId = appId;
+        }
+
+        public String getUrlRuleId() {
+            return urlRuleId;
+        }
+
+        public void setUrlRuleId(String urlRuleId) {
+            this.urlRuleId = urlRuleId;
+        }
+
+        public String getParamType() {
+            return paramType;
+        }
+
+        public void setParamType(String paramType) {
+            this.paramType = paramType;
+        }
+
+        public List<ValueRule> getValueRuleList() {
+            return valueRuleList;
+        }
+
+        public void setValueRuleList(List<ValueRule> valueRuleList) {
+            this.valueRuleList = valueRuleList;
+        }
+    }
+
+    public static class ValueRule {
+        private String key;
+        private String value;
+
+        public String getKey() {
+            return key;
+        }
+
+        public void setKey(String key) {
+            this.key = key;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
         }
     }
 }

--- a/arex-instrumentation-foundation/src/test/java/io/arex/foundation/config/ConfigManagerTest.java
+++ b/arex-instrumentation-foundation/src/test/java/io/arex/foundation/config/ConfigManagerTest.java
@@ -4,9 +4,13 @@ import io.arex.agent.bootstrap.constants.ConfigConstants;
 import io.arex.agent.bootstrap.util.StringUtil;
 import io.arex.foundation.model.ConfigQueryResponse;
 import io.arex.foundation.model.ConfigQueryResponse.DynamicClassConfiguration;
+import io.arex.foundation.model.ConfigQueryResponse.ParamRule;
+import io.arex.foundation.model.ConfigQueryResponse.RecordUrlConfiguration;
+import io.arex.foundation.model.ConfigQueryResponse.ValueRule;
 import io.arex.inst.runtime.model.ArexConstants;
 import io.arex.inst.runtime.model.DynamicClassEntity;
 import io.arex.inst.runtime.model.DynamicClassStatusEnum;
+import io.arex.inst.runtime.util.IgnoreUtils;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -90,6 +94,96 @@ class ConfigManagerTest {
         excludeOperations.add("mock");
         configManager.setExcludeServiceOperations(excludeOperations);
         assertFalse(configManager.getExcludeServiceOperations().isEmpty());
+    }
+
+    private RecordUrlConfiguration getRecordUrlConfig() {
+        RecordUrlConfiguration recordUrlConfig = new RecordUrlConfiguration();
+        recordUrlConfig.setId("mock-record-rule-id");
+        recordUrlConfig.setAppId("unit-test-service");
+        recordUrlConfig.setHttpPath("/unitTestHttpPath");
+        return recordUrlConfig;
+    }
+
+    @Test
+    void setRecordRule() {
+        // record rule size = 0
+        assertEquals(0, configManager.getRecordRuleList().size());
+        assertFalse(configManager.isExistUrlParamRule());
+        assertFalse(configManager.isExistBodyParamRule());
+
+        // record rule size = 1
+        List<RecordUrlConfiguration> recordRuleConfigList = new ArrayList<>();
+        RecordUrlConfiguration recordUrlConfig = getRecordUrlConfig();
+        recordRuleConfigList.add(recordUrlConfig);
+        configManager.setRecordRuleEntityList(recordRuleConfigList);
+        assertEquals(1, configManager.getRecordRuleList().size());
+        assertFalse(configManager.isExistUrlParamRule());
+        assertFalse(configManager.isExistBodyParamRule());
+    }
+
+    private ParamRule getUrlParamRule() {
+        ParamRule paramRule = new ParamRule();
+        paramRule.setId("mock-param-rule-id");
+        paramRule.setAppId("unit-test-service");
+        paramRule.setUrlRuleId("mock-record-rule-id");
+        paramRule.setParamType(IgnoreUtils.PARAM_TYPE_QUERY_STRING);
+        List<ValueRule> valueRuleList = new ArrayList<>();
+        valueRuleList.add(getValueRule());
+        paramRule.setValueRuleList(valueRuleList);
+        return paramRule;
+    }
+
+    private ParamRule getBodyParamRule() {
+        ParamRule paramRule = new ParamRule();
+        paramRule.setId("mock-param-rule-id");
+        paramRule.setAppId("unit-test-service");
+        paramRule.setUrlRuleId("mock-record-rule-id");
+        paramRule.setParamType(IgnoreUtils.PARAM_TYPE_JSON_BODY);
+        List<ValueRule> valueRuleList = new ArrayList<>();
+        valueRuleList.add(getValueRule());
+        paramRule.setValueRuleList(valueRuleList);
+        return paramRule;
+    }
+
+    private ValueRule getValueRule() {
+        ValueRule valueRule = new ValueRule();
+        valueRule.setKey("key");
+        valueRule.setValue("value");
+        return valueRule;
+    }
+
+    @Test
+    void setUrlParamRule() {
+        assertFalse(configManager.isExistUrlParamRule());
+        assertFalse(configManager.isExistBodyParamRule());
+
+        // url param rule size = 1
+        List<RecordUrlConfiguration> recordRuleConfigList = new ArrayList<>();
+        RecordUrlConfiguration recordUrlConfig = getRecordUrlConfig();
+        List<ParamRule> paramRuleList = new ArrayList<>();
+        paramRuleList.add(getUrlParamRule());
+        recordUrlConfig.setParamRuleList(paramRuleList);
+        recordRuleConfigList.add(recordUrlConfig);
+        configManager.setRecordRuleEntityList(recordRuleConfigList);
+        assertTrue(configManager.isExistUrlParamRule());
+        assertFalse(configManager.isExistBodyParamRule());
+    }
+
+    @Test
+    void setBodyParamRule() {
+        assertFalse(configManager.isExistUrlParamRule());
+        assertFalse(configManager.isExistBodyParamRule());
+
+        // url param rule size = 1
+        List<RecordUrlConfiguration> recordRuleConfigList = new ArrayList<>();
+        RecordUrlConfiguration recordUrlConfig = getRecordUrlConfig();
+        List<ParamRule> paramRuleList = new ArrayList<>();
+        paramRuleList.add(getBodyParamRule());
+        recordUrlConfig.setParamRuleList(paramRuleList);
+        recordRuleConfigList.add(recordUrlConfig);
+        configManager.setRecordRuleEntityList(recordRuleConfigList);
+        assertFalse(configManager.isExistUrlParamRule());
+        assertTrue(configManager.isExistBodyParamRule());
     }
 
     @Test

--- a/arex-instrumentation-foundation/src/test/java/io/arex/foundation/services/ConfigServiceTest.java
+++ b/arex-instrumentation-foundation/src/test/java/io/arex/foundation/services/ConfigServiceTest.java
@@ -14,6 +14,7 @@ import io.arex.foundation.model.AgentStatusEnum;
 import io.arex.foundation.model.AgentStatusRequest;
 import io.arex.foundation.model.ConfigQueryRequest;
 import io.arex.foundation.model.ConfigQueryResponse;
+import io.arex.foundation.model.ConfigQueryResponse.RecordUrlConfiguration;
 import io.arex.foundation.model.ConfigQueryResponse.ResponseBody;
 import io.arex.foundation.model.ConfigQueryResponse.ServiceCollectConfig;
 import io.arex.foundation.model.HttpClientResponse;
@@ -21,9 +22,7 @@ import io.arex.foundation.serializer.jackson.JacksonSerializer;
 import io.arex.foundation.util.NetUtils;
 import io.arex.foundation.util.httpclient.AsyncHttpClientUtil;
 import java.time.DayOfWeek;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -132,6 +131,18 @@ class ConfigServiceTest {
             assertEquals(DELAY_MINUTES, ConfigService.INSTANCE.loadAgentConfig(null));
             assertTrue(ConfigManager.INSTANCE.inWorkingTime() && ConfigManager.INSTANCE.getRecordRate() > 0);
             assertEquals(AgentStatusEnum.WORKING, ConfigService.INSTANCE.getAgentStatus());
+
+            // record rule size = 0
+            assertEquals(0, ConfigManager.INSTANCE.getRecordRuleList().size());
+            List<RecordUrlConfiguration> recordRuleConfigList = new ArrayList<>();
+            RecordUrlConfiguration recordUrlConfig = new RecordUrlConfiguration();
+            recordRuleConfigList.add(recordUrlConfig);
+            responseBody.setRecordUrlConfigurationList(recordRuleConfigList);
+            configQueryResponse.setBody(responseBody);
+            response = CompletableFuture.completedFuture(new HttpClientResponse(200, null, JacksonSerializer.INSTANCE.serialize(configQueryResponse)));
+            ahc.when(() -> AsyncHttpClientUtil.postAsyncWithJson(anyString(), anyString(), eq(null))).thenReturn(response);
+            assertEquals(DELAY_MINUTES, ConfigService.INSTANCE.loadAgentConfig(null));
+            assertEquals(1, ConfigManager.INSTANCE.getRecordRuleList().size());
         }
     }
 


### PR DESCRIPTION
feat: 'request param record rule' 

The response content of the http://{arex. storage. hostname}/ai/config/agent/load interface,
Add recording rule parameters and parse them into the ConfigManager.INSTANCE

```json
{
    "responseStatusType": {
    },
    "body": {
        "recordUrlConfigurationList": [
            {
                "appId": "unit-test-service",
                "id": "mock-record-rule-id",
                "httpPath": "/dbTest/mybatis",
                "paramRuleList": [
                    {
                        "appId": "unit-test-service",
                        "urlRuleId": "mock-record-rule-id",
                        "id": "mock-param-rule-id",
                        "paramType": "QUERY_STRING", 
                        "valueRuleList": [
                            {
                                "key": "key",
                                "value": "value"
                            }
                        ]
                    }
                ]
            }
        ]
    }
}
```