### PR TITLE
feat: add root object

### DIFF
--- a/arex-instrumentation/dynamic/arex-dynamic-common/src/main/java/io/arex/inst/dynamic/common/ExpressionParseUtil.java
+++ b/arex-instrumentation/dynamic/arex-dynamic-common/src/main/java/io/arex/inst/dynamic/common/ExpressionParseUtil.java
@@ -42,14 +42,16 @@ public class ExpressionParseUtil {
         if (expression == null) {
             return null;
         }
-        // create root object
-        MethodRootObject rootObject = new MethodRootObject(method, args);
+
 
         try {
             String[] parameterNames = NAME_DISCOVERER.getParameterNames(method);
             if (parameterNames == null || args.length != parameterNames.length) {
                 return null;
             }
+
+            MethodRootObject rootObject = new MethodRootObject(method, args);
+
             EvaluationContext context = new StandardEvaluationContext(rootObject);
             for (int i = 0; i < args.length; i++) {
                 context.setVariable(parameterNames[i], args[i]);
@@ -64,7 +66,10 @@ public class ExpressionParseUtil {
         }
     }
 
-
+    /**
+     * the root object used during the expression evaluation. It contains the method and its
+     * arguments.
+     */
     private static class MethodRootObject {
         private final Method method;
         private final Object[] args;

--- a/arex-instrumentation/dynamic/arex-dynamic-common/src/main/java/io/arex/inst/dynamic/common/ExpressionParseUtil.java
+++ b/arex-instrumentation/dynamic/arex-dynamic-common/src/main/java/io/arex/inst/dynamic/common/ExpressionParseUtil.java
@@ -42,13 +42,15 @@ public class ExpressionParseUtil {
         if (expression == null) {
             return null;
         }
+        // create root object
+        MethodRootObject rootObject = new MethodRootObject(method, args);
 
         try {
             String[] parameterNames = NAME_DISCOVERER.getParameterNames(method);
             if (parameterNames == null || args.length != parameterNames.length) {
                 return null;
             }
-            EvaluationContext context = new StandardEvaluationContext();
+            EvaluationContext context = new StandardEvaluationContext(rootObject);
             for (int i = 0; i < args.length; i++) {
                 context.setVariable(parameterNames[i], args[i]);
             }
@@ -60,6 +62,30 @@ public class ExpressionParseUtil {
         } catch (Exception e) {
             return null;
         }
+    }
+
+
+    private static class MethodRootObject {
+        private final Method method;
+        private final Object[] args;
+
+        private MethodRootObject(Method method, Object[] args) {
+            this.method = method;
+            this.args = args;
+        }
+
+        public String getMethodName() {
+            return method.getName();
+        }
+
+        public Method getMethod() {
+            return this.method;
+        }
+
+        public Object[] getArgs() {
+            return this.args;
+        }
+
     }
 
     public static String replaceToExpression(Method method, String additionalSignature) {

--- a/arex-instrumentation/dynamic/arex-dynamic-common/src/test/java/io/arex/inst/dynamic/common/ExpressionParseUtilTest.java
+++ b/arex-instrumentation/dynamic/arex-dynamic-common/src/test/java/io/arex/inst/dynamic/common/ExpressionParseUtilTest.java
@@ -114,6 +114,42 @@ class ExpressionParseUtilTest {
                     Foo1.class),
                 "T(io.arex.inst.dynamic.common.ExpressionParseUtilTest).getMapKey(#f1.f1, #f1.f2)",
                 (Predicate<String>) "getMapKey-p1-1"::equals
+            ),
+            Arguments.of(
+                new Object[]{
+                    new Foo2("p1", 1),
+                    new Foo2("p2", 2),
+                    new Foo1(new Foo2("p3", 3))
+                },
+                ExpressionParseUtilTest.class.getDeclaredMethod("testParseMethodKey3", Foo2.class,
+                    Foo2.class,
+                    Foo1.class),
+                "#root.methodName + #f1.getF2() + #f2.getF2().toString() + #f3.getFoo2().f1",
+                (Predicate<String>) "testParseMethodKey312p3"::equals
+            ),
+            Arguments.of(
+                new Object[]{
+                    new Foo2("p1", 1),
+                    new Foo2("p2", 2),
+                    new Foo1(new Foo2("p3", 3))
+                },
+                ExpressionParseUtilTest.class.getDeclaredMethod("testParseMethodKey3", Foo2.class,
+                    Foo2.class,
+                    Foo1.class),
+                "#root.method.name + #f1.getF2() + #f2.getF2().toString() + #f3.getFoo2().f1",
+                (Predicate<String>) "testParseMethodKey312p3"::equals
+            ),
+            Arguments.of(
+                new Object[]{
+                    new Foo2("p1", 1),
+                    new Foo2("p2", 2),
+                    new Foo1(new Foo2("p3", 3))
+                },
+                ExpressionParseUtilTest.class.getDeclaredMethod("testParseMethodKey3", Foo2.class,
+                    Foo2.class,
+                    Foo1.class),
+                "#root.args[0].getF2().toString + #f1.getF2() + #f2.getF2().toString() + #f3.getFoo2().f1",
+                (Predicate<String>) "112p3"::equals
             )
         );
     }


### PR DESCRIPTION
Problem: Root built-in functions, such as # root.mathodName, are not supported, 
such as: Spring @Cache annotation has a key construction exception, recording in empty input parameters:
![image](https://github.com/user-attachments/assets/20b613e2-84b5-4ca8-85f0-8fc1b93926d4)

Fix solution: By constructing a root object, support parsing root functions using spel expressions.