### PR TITLE
fix: concurrent modification exception

### DIFF
--- a/arex-agent-bootstrap/src/main/java/io/arex/agent/bootstrap/model/MockCategoryType.java
+++ b/arex-agent-bootstrap/src/main/java/io/arex/agent/bootstrap/model/MockCategoryType.java
@@ -4,10 +4,11 @@ import java.io.Serializable;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class MockCategoryType implements Serializable {
 
-    private static final Map<String, MockCategoryType> CATEGORY_TYPE_MAP = new HashMap<>();
+    private static final Map<String, MockCategoryType> CATEGORY_TYPE_MAP = new ConcurrentHashMap<>(16);
     public static final MockCategoryType SERVLET = createEntryPoint("Servlet");
     public static final MockCategoryType DATABASE = createDependency("Database");
     public static final MockCategoryType HTTP_CLIENT = createDependency("HttpClient");

--- a/arex-agent-bootstrap/src/test/java/io/arex/agent/bootstrap/model/MockCategoryTypeTest.java
+++ b/arex-agent-bootstrap/src/test/java/io/arex/agent/bootstrap/model/MockCategoryTypeTest.java
@@ -1,0 +1,56 @@
+package io.arex.agent.bootstrap.model;
+
+import io.arex.agent.bootstrap.util.Assert;
+import org.junit.jupiter.api.Test;
+
+import java.util.ConcurrentModificationException;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CyclicBarrier;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+public class MockCategoryTypeTest {
+
+    private static volatile boolean isError = false;
+
+    @Test
+    public void test_Create() {
+        CyclicBarrier barrier = new CyclicBarrier(10);
+        Thread[] threads = new Thread[10];
+        for (int i = 0; i < 10; i++) {
+            threads[i] = new Thread(new Task(barrier, "test" + i));
+            threads[i].start();
+        }
+        for (Thread thread : threads) {
+            try {
+                thread.join();
+            } catch (InterruptedException e) {
+
+            }
+        }
+        assertFalse(isError, "MockCategoryType create method should not throw exception");
+    }
+
+    static class Task implements Runnable {
+        private final CyclicBarrier barrier;
+        private final String name;
+
+        public Task(CyclicBarrier barrier, String name) {
+            this.barrier = barrier;
+            this.name = name;
+        }
+
+        @Override
+        public void run() {
+            try {
+                barrier.await();
+                MockCategoryType.create(name, true, false);
+            } catch (InterruptedException | BrokenBarrierException e) {
+
+            } catch (ConcurrentModificationException e) {
+                isError = true;
+            }
+        }
+    }
+}


### PR DESCRIPTION
When extending the MockCategoryType class, there is a concurrent modification exception in a multi-threaded environment, which ultimately leads to data loss during recording.