### PR TITLE
Update ApacheHttpClientAdapterTest.java fix gzip byte array

### DIFF
--- a/arex-instrumentation/httpclient/arex-httpclient-apache-v4/src/test/java/io/arex/inst/httpclient/apache/common/ApacheHttpClientAdapterTest.java
+++ b/arex-instrumentation/httpclient/arex-httpclient-apache-v4/src/test/java/io/arex/inst/httpclient/apache/common/ApacheHttpClientAdapterTest.java
@@ -79,7 +79,7 @@ class ApacheHttpClientAdapterTest {
         HttpPost nullEntityRequest = new HttpPost();
 
         return Stream.of(
-                arguments(httpPostWithGzipEntity, new byte[]{31, -117, 8, 0, 0, 0, 0, 0, 0, -1, -53, -51, 79, -50, 6, 0, 107, -4, 51, 63, 4, 0, 0, 0}),
+                arguments(httpPostWithGzipEntity, new byte[]{31, -117, 8, 0, 0, 0, 0, 0, 0, 0, -53, -51, 79, -50, 6, 0, 107, -4, 51, 63, 4, 0, 0, 0}),
                 arguments(request, new byte[0]),
                 arguments(httpPost, "mock".getBytes()),
                 arguments(httpPostWithoutContent, new byte[0]),


### PR DESCRIPTION
fix gzip byte array

correct "mock" string byte array is 
```
new byte[]{31, -117, 8, 0, 0, 0, 0, 0, 0, 0, -53, -51, 79, -50, 6, 0, 107, -4, 51, 63, 4, 0, 0, 0}
```

gzip code
```
public static void main(String[] args) throws Exception {
        String text = "mock";

        byte[] compressed = compress(text);

        System.out.println(toJavaByteArray(compressed));
    }

    public static byte[] compress(String str) throws Exception {
        ByteArrayOutputStream bos = new ByteArrayOutputStream();
        try (GZIPOutputStream gzip = new GZIPOutputStream(bos)) {
            gzip.write(str.getBytes(StandardCharsets.UTF_8));
        }
        return bos.toByteArray();
    }

    public static String toJavaByteArray(byte[] data) {
        StringBuilder sb = new StringBuilder("new byte[]{");
        for (int i = 0; i < data.length; i++) {
            sb.append(data[i]);
            if (i < data.length - 1) {
                sb.append(", ");
            }
        }
        sb.append("};");
        return sb.toString();
    }
```