### PR TITLE
fix: feign RepeatedCollectManager depth leak causing record miss (#587)

### DIFF
--- a/arex-instrumentation/httpclient/arex-httpclient-feign/src/main/java/io/arex/inst/httpclient/feign/FeignClientInstrumentation.java
+++ b/arex-instrumentation/httpclient/arex-httpclient-feign/src/main/java/io/arex/inst/httpclient/feign/FeignClientInstrumentation.java
@@ -52,10 +52,13 @@ public class FeignClientInstrumentation extends TypeInstrumentation {
                 if (IgnoreUtils.excludeOperation(uri.getPath())) {
                     return false;
                 }
+                // check outermost before enter() so nested http clients (e.g. Feign -> Apache)
+                // skip replay and avoid request body double consumption
+                boolean isOutermost = RepeatedCollectManager.validate();
                 RepeatedCollectManager.enter();
                 adapter = new FeignClientAdapter(request, uri);
                 extractor = new HttpClientExtractor(adapter);
-                if (ContextManager.needReplay()) {
+                if (ContextManager.needReplay() && isOutermost) {
                     mockResult = extractor.replay();
                     return mockResult != null && mockResult.notIgnoreMockResult();
                 }
@@ -73,6 +76,9 @@ public class FeignClientInstrumentation extends TypeInstrumentation {
                 return;
             }
 
+            // pair enter() unconditionally to keep CallDepth balanced across replay/record mixed flows
+            boolean isOutermost = RepeatedCollectManager.exitAndValidate();
+
             if (mockResult != null && mockResult.notIgnoreMockResult()) {
                 if (mockResult.getThrowable() != null) {
                     throwable = mockResult.getThrowable();
@@ -82,7 +88,7 @@ public class FeignClientInstrumentation extends TypeInstrumentation {
                 return;
             }
 
-            if (ContextManager.needRecord() && RepeatedCollectManager.exitAndValidate()) {
+            if (ContextManager.needRecord() && isOutermost) {
                 response = adapter.copyResponse(response);
                 if (throwable != null) {
                     extractor.record(throwable);

--- a/arex-instrumentation/httpclient/arex-httpclient-feign/src/test/java/io/arex/inst/httpclient/feign/FeignClientInstrumentationTest.java
+++ b/arex-instrumentation/httpclient/arex-httpclient-feign/src/test/java/io/arex/inst/httpclient/feign/FeignClientInstrumentationTest.java
@@ -66,7 +66,12 @@ class FeignClientInstrumentationTest {
 
         // need replay and not exclude operation
         Mockito.when(ContextManager.needReplay()).thenReturn(true);
+        Mockito.when(RepeatedCollectManager.validate()).thenReturn(true);
         assertTrue(FeignClientInstrumentation.ExecuteAdvice.onEnter(request, null, null, null));
+
+        // nested call: outer already entered, inner replay should be skipped
+        Mockito.when(RepeatedCollectManager.validate()).thenReturn(false);
+        assertFalse(FeignClientInstrumentation.ExecuteAdvice.onEnter(request, null, null, null));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fix #587 — under mixed record/replay traffic on the same thread, some requests silently fail to record (issue reports ~10% failure rate; user observed `CallDepth` reaching 9 while a normal call chain tops out at 4). Root cause is unbalanced `RepeatedCollectManager.enter()` / `exitAndValidate()` in the Feign advice.

## Root cause

In `FeignClientInstrumentation.ExecuteAdvice`:

- `onEnter` calls `RepeatedCollectManager.enter()` unconditionally when `needRecordOrReplay()`
- `onExit` returns early inside the `mockResult != null && notIgnoreMockResult()` branch, **without** calling `exitAndValidate()`

Every replay-hit request therefore leaks `+1` on the thread-local `CallDepth`. Once depth passes 1, subsequent record attempts on the same thread see `exitAndValidate() == false` and are dropped. This explains the "10% requests not recorded / depth up to 9" symptom in the issue.

There's also a latent bug in the same code path: nested http clients (e.g. Feign wrapping Apache HttpClient via `feign-httpclient`) both try to replay, and the inner client re-consumes the request body — leading to replay-match misses.

## Changes

`FeignClientInstrumentation.java`:

1. **outermost check moved before `enter()`** — capture `boolean isOutermost = RepeatedCollectManager.validate()` first, so a nested call detects it's inside an already-entered scope and skips its own replay.
2. **replay gated on `isOutermost`** — inner nested clients no longer double-consume the request body.
3. **`exitAndValidate()` called unconditionally at top of `onExit`** — mock hits now decrement `CallDepth` too, keeping enter/exit balanced. The saved `isOutermost` is used for the record gate.

`FeignClientInstrumentationTest.java`:

- add stub for `RepeatedCollectManager.validate()` in the existing replay-path assertion
- add a nested-call case asserting inner replay is skipped when outer already entered

## Test plan

- [x] `mvn -pl arex-instrumentation/httpclient/arex-httpclient-feign test` — 12/12 pass
- [x] Reviewer: verify against the original reproducer in #587 (feign + mixed record/replay traffic)