### PR TITLE
chore: bump revision to 0.4.10 for release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
 
     <properties>
         <!-- Maven CI Friendly Versions https://maven.apache.org/maven-ci-friendly.html -->
-        <revision>0.4.8</revision>
+        <revision>0.4.10</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 


### PR DESCRIPTION
Bump `<revision>` from `0.4.8` to `0.4.10` in preparation for the next release.

The last release was v0.4.8 (2024-11-29). Five commits have landed on `main` since then:

- fix: uri append (#594)
- fix: Redisson getBucket(String, Codec) bug fix (#604)
- feat: add root object (#605)
- fix: concurrent modification exception (#613)
- fix: feign RepeatedCollectManager depth leak causing record miss (#587) (#622)

Version numbering follows the existing even-increment convention
(v0.4.4 → v0.4.6 → v0.4.8 → v0.4.10).

Single-line change; `0.4.8` appears nowhere else in the repository.